### PR TITLE
conf: Add common configuration for all supported HW

### DIFF
--- a/prj.conf
+++ b/prj.conf
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Zephyr based EC FW project configuration
+
+# Logs enabled by default in development, this is overridden in build system
+# to ensure releases are correctly generated
+CONFIG_LOG=y
+CONFIG_LOG_PROCESS_THREAD_SLEEP_MS=1200
+
+# EC FW features configuration
+# ----------------------------
+CONFIG_ESPI_PERIPHERAL_HOST_IO_PVT=n
+CONFIG_THERMAL_MANAGEMENT=y
+
+# Enable support for OOB Manager
+CONFIG_OOBMNGR_SUPPORT=y
+
+# Zephyr kernel/driver configuration required by EC FW
+# ----------------------------------------------------
+CONFIG_SOC_MEC1501_VCI_PINS_AS_GPIOS=y
+CONFIG_WATCHDOG=y
+
+# EC FW flows require to intercept host warnings
+CONFIG_ESPI_AUTOMATIC_WARNING_ACKNOWLEDGE=n
+
+# EC FW requires eSPI driver OOB Rx callback
+CONFIG_ESPI_OOB_CHANNEL_RX_ASYNC=y
+
+# Enable IO expander support
+CONFIG_GPIO_PCA95XX=y
+
+# Required for SAF
+CONFIG_ESPI_FLASH_CHANNEL=y
+
+# SAF required drivers
+CONFIG_SPI=y
+CONFIG_ESPI_SAF=y
+CONFIG_SAF_SPI_CAPACITY=32
+
+# Kernel debug features
+# ---------------------
+CONFIG_THREAD_NAME=y
+CONFIG_STACK_SENTINEL=y


### PR DESCRIPTION
Add common EC FW features applicable to all boards supported.
Individual configuration is located under board-specific .conf
files in boards folder.

Signed-off-by: Jose Alberto Meza <jose.a.meza.arellano@intel.com>