### PR TITLE
app/debug: Fix build error if postcode management disabled

### DIFF
--- a/app/debug/Kconfig
+++ b/app/debug/Kconfig
@@ -16,7 +16,11 @@ config POSTCODE_LOG_LEVEL
 	int "Debug Port80 log level"
 	depends on LOG
 	depends on POSTCODE_MANAGEMENT
+	default 2 if EC_DEBUG_LOG_LEVEL
 	default 0
-	default 2 if CONFIG_EC_DEBUG_LOG_LEVEL
 	help
 	  Set log level for debug Port 80 log level.
+
+config ESPI_PERIPHERAL_DEBUG_PORT_80
+	default y if POSTCODE_MANAGEMENT
+	default n

--- a/app/power_sequencing/pwrplane.c
+++ b/app/power_sequencing/pwrplane.c
@@ -288,7 +288,9 @@ void pwrseq_error(uint8_t error_code)
 	LOG_ERR("%s: %d", __func__, error_code);
 
 	pwrseq_failure = true;
+#ifdef CONFIG_POSTCODE_MANAGEMENT
 	update_error(error_code);
+#endif
 	k_msleep(100);
 	gpio_write_pin(PCH_PWROK, 0);
 	gpio_write_pin(SYS_PWROK, 0);
@@ -300,8 +302,10 @@ void pwrseq_reset(void)
 
 	pwrseq_failure = false;
 
+#ifdef CONFIG_POSTCODE_MANAGEMENT
 	/* Clear port 80 */
 	update_error(ERR_NONE);
+#endif
 }
 
 static inline int pwrseq_task_init(void)
@@ -642,7 +646,9 @@ static void power_off(void)
 		level = gpio_get_pin(PWRBTN_EC_IN_N);
 	} while (!level);
 
+#ifdef CONFIG_POSTCODE_MANAGEMENT
 	port80_display_off();
+#endif
 
 	gpio_write_pin(EC_PWRBTN_LED, LOW);
 	LOG_DBG("Power off complete");
@@ -677,7 +683,9 @@ static int power_on(void)
 		return ret;
 	}
 
+#ifdef CONFIG_POSTCODE_MANAGEMENT
 	port80_display_on();
+#endif
 
 	/* Check for SLPS5#, SLPS4#, SLPS3# signals */
 	ret = check_slp_signals();
@@ -759,7 +767,9 @@ static void suspend(void)
 	gpio_write_pin(PCH_PWROK, 0);
 	gpio_write_pin(SYS_PWROK, 0);
 	board_suspend();
+#ifdef CONFIG_POSTCODE_MANAGEMENT
 	port80_display_off();
+#endif
 }
 
 static int resume(void)

--- a/app/power_sequencing/pwrseq_utils.c
+++ b/app/power_sequencing/pwrseq_utils.c
@@ -61,7 +61,9 @@ void ec_reset(void)
 
 	gpio_write_pin(SYS_PWROK, 0);
 	gpio_write_pin(PCH_PWROK, 0);
+#ifdef CONFIG_POSTCODE_MANAGEMENT
 	port80_display_off();
+#endif
 	/* The busy wait is required to block the execution
 	 * and to ramp down the above signals. Ideally, these should
 	 * not be altered by any other thread.


### PR DESCRIPTION
Add #ifdef to postcode management related fuctions to fix build
errors when postcode is not used by the platform.
Disable ESPI_PERIPHERAL_DEBUG_PORT_80 when POSTCODE_MANAGEMENT is
disabled. It also fixes the POSTCODE_LOG_LEVEL default value not
configured properly.

Signed-off-by: Lean Sheng Tan <sheng.tan@9elements.com>