### PR TITLE
app: fix build error from distinguish CONFIG of app

### DIFF
--- a/app/app.c
+++ b/app/app.c
@@ -36,11 +36,13 @@ void main(void)
 	 * because we must query the boot mode before assigning functions
 	 * to certain pins
 	 */
+#ifdef CONFIG_ESPI
 	ret = espihub_init();
 	if (ret) {
 		LOG_ERR("Failed to init espi %d", ret);
 		return;
 	}
+#endif
 
 	ret = board_init();
 	if (ret) {

--- a/app/peripheral_management/periphmgmt.c
+++ b/app/peripheral_management/periphmgmt.c
@@ -196,6 +196,8 @@ int periph_register_button(uint32_t port_pin, btn_handler_t handler)
 	return ret;
 }
 
+#ifdef CONFIG_SMCHOST
+
 void update_virtual_bat_dock_status(void)
 {
 	int level;
@@ -226,6 +228,8 @@ bool is_virtual_dock_prsnt(void)
 {
 	return g_acpi_tbl.acpi_flags2.pcie_docked;
 }
+
+#endif	/* CONFIG_SMCHOST */
 
 void periph_thread(void *p1, void *p2, void *p3)
 {

--- a/app/power_sequencing/deepsx.c
+++ b/app/power_sequencing/deepsx.c
@@ -387,7 +387,9 @@ void deep_sx_enter(void)
 	if (espihub_reset_status() && !sus_wrn) {
 		gpio_write_pin(PM_DS3, 1);
 
+#if defined (CONFIG_SOC_FAMILY_MEC)
 		vci_enable();
+#endif
 
 		ret = ack_deep_sleep_transition(SUS_WRN_LOW);
 		if (ret) {
@@ -426,6 +428,7 @@ void deep_sx_enter(void)
 
 void deep_sx_exit(void)
 {
+#if defined (CONFIG_SOC_FAMILY_MEC)
 	switch (vci_wake_reason()) {
 	case VCI_POWER_BUTTON:
 		/* If power button press detected by VCI, wake the system */
@@ -439,4 +442,7 @@ void deep_sx_exit(void)
 		LOG_WRN("DSx wake not supported");
 		break;
 	}
+#else
+	LOG_WRN("DSx wake not supported");
+#endif
 }

--- a/app/power_sequencing/pseudog3.c
+++ b/app/power_sequencing/pseudog3.c
@@ -69,11 +69,13 @@ static void pseudo_g3_enter(void)
 		return;
 	}
 
+#ifdef CONFIG_SMCHOST
 	/* If system is in Virtual battery mode enter PG3 */
 	if (ac_prsnt && !is_virtual_battery_prsnt()) {
 		LOG_DBG("Can not enter Pseudo G3 until AC present.");
 		return;
 	}
+#endif
 
 	espihub_retrieve_vw(ESPI_VWIRE_SIGNAL_SUS_PWRDN_ACK, &sus_pwrdn_ack);
 

--- a/app/power_sequencing/pwrseq_utils.c
+++ b/app/power_sequencing/pwrseq_utils.c
@@ -10,7 +10,9 @@
 #include <device.h>
 #include "board.h"
 #include "board_config.h"
+#ifdef CONFIG_POSTCODE_MANAGEMENT
 #include "port80display.h"
+#endif
 LOG_MODULE_DECLARE(pwrmgmt, CONFIG_PWRMGT_LOG_LEVEL);
 
 /* This reset delay value is finalized as per the debug experiments

--- a/app/soc_debug_awareness/soc_debug.c
+++ b/app/soc_debug_awareness/soc_debug.c
@@ -13,7 +13,8 @@
 #include "periphmgmt.h"
 #include "pwrseq_utils.h"
 #include "kbs_matrix.h"
-LOG_MODULE_REGISTER(soc_debug, CONFIG_PWRMGT_LOG_LEVEL);
+
+LOG_MODULE_REGISTER(soc_debug, CONFIG_BOARD_LOG_LEVEL);
 
 #ifdef CONFIG_SOC_DEBUG_CONSENT_GPIO
 struct k_work_delayable sampling_work;

--- a/boards/microchip/adl_mec1501.c
+++ b/boards/microchip/adl_mec1501.c
@@ -106,6 +106,7 @@ struct gpio_ec_config mecc1501_cfg_sus[] =  {
 struct gpio_ec_config mecc1501_cfg_res[] =  {
 };
 
+#ifdef CONFIG_THERMAL_MANAGEMENT
 /**
  * @brief Fan device table.
  *
@@ -116,7 +117,6 @@ static struct fan_dev fan_tbl[] = {
 /*	PWM_CH_##	TACH_CH_##  */
 	{ PWM_CH_00,	TACH_CH_00 }, /* CPU Fan */
 };
-
 
 /**
  * @brief Thermal sensor table.
@@ -165,6 +165,8 @@ void board_fan_dev_tbl_init(uint8_t *pmax_fan, struct fan_dev **pfan_tbl)
 	*pfan_tbl = fan_tbl;
 	*pmax_fan = ARRAY_SIZE(fan_tbl);
 }
+
+#endif /* CONFIG_THERMAL_MANAGEMENT */
 
 void board_config_io_buffer(void)
 {

--- a/boards/microchip/adl_p_mec1501.c
+++ b/boards/microchip/adl_p_mec1501.c
@@ -153,6 +153,7 @@ struct gpio_ec_config mecc1501_cfg_sus[] =  {
 struct gpio_ec_config mecc1501_cfg_res[] =  {
 };
 
+#ifdef CONFIG_THERMAL_MANAGEMENT
 /**
  * @brief Fan device table.
  *
@@ -205,6 +206,7 @@ void board_fan_dev_tbl_init(uint8_t *pmax_fan, struct fan_dev **pfan_tbl)
 	*pmax_fan = ARRAY_SIZE(fan_tbl);
 }
 
+#endif /* CONFIG_THERMAL_MANAGEMENT */
 
 void update_platform_sku_type(void)
 {

--- a/drivers/espi_hub.h
+++ b/drivers/espi_hub.h
@@ -27,8 +27,13 @@
 #define MAX_PERIPH_HANDLERS       2u
 
 /* TODO: Check if we can replace these macros */
+#ifdef CONFIG_SOC_FAMILY_MEC
 #define KBC_IBF_DATA(x)           (((x) >> E8042_ISR_DATA_POS) & 0xFFU)
 #define KBC_CMD_DATA(x)           ((x) & 0xFU)
+#else	/* struct espi_evt_data_kbc */
+#define KBC_IBF_DATA(x)           (((x) >> 8) & 0xFFU)	/* .data */
+#define KBC_CMD_DATA(x)           ((x) & 0xFU)	/* .type */
+#endif
 
 /* TODO: Replace these macros with Zephyr byte order */
 #define ESPI_PERIPHERAL_TYPE(x)   ((x) & 0x0000FFFF)

--- a/misc/task_handler.c
+++ b/misc/task_handler.c
@@ -20,7 +20,7 @@
 #include "thermalmgmt.h"
 #endif
 
-LOG_MODULE_DECLARE(pwrmgmt, CONFIG_PWRMGT_LOG_LEVEL);
+LOG_MODULE_DECLARE(thrdmgmt, CONFIG_EC_LOG_LEVEL);
 
 #define EC_TASK_STACK_SIZE	1024
 
@@ -53,21 +53,29 @@ K_THREAD_DEFINE(postcode_thrd_id, EC_TASK_STACK_SIZE, postcode_thread,
 		K_INHERIT_PERMS, EC_WAIT_FOREVER);
 #endif
 
+#ifdef CONFIG_PERIPHERAL_MANAGEMENT
 K_THREAD_DEFINE(periph_thrd_id, EC_TASK_STACK_SIZE, periph_thread,
 		&periph_thrd_period, NULL, NULL, EC_TASK_PRIORITY,
 		K_INHERIT_PERMS, EC_WAIT_FOREVER);
+#endif
 
+#ifdef CONFIG_PWRMGMT
 K_THREAD_DEFINE(pwrseq_thrd_id, EC_TASK_STACK_SIZE, pwrseq_thread,
 		&pwrseq_thrd_period, NULL, NULL, EC_TASK_PRIORITY,
 		K_INHERIT_PERMS, EC_WAIT_FOREVER);
+#endif
 
+#ifdef CONFIG_ESPI
 K_THREAD_DEFINE(oobmngr_thrd_id, EC_TASK_STACK_SIZE, oobmngr_thread,
 		NULL, NULL, NULL, EC_TASK_PRIORITY,
 		K_INHERIT_PERMS, EC_WAIT_FOREVER);
+#endif
 
+#ifdef CONFIG_SMCHOST
 K_THREAD_DEFINE(smchost_thrd_id, EC_TASK_STACK_SIZE, smchost_thread,
 		&smchost_thrd_period, NULL, NULL, EC_TASK_PRIORITY,
 		K_INHERIT_PERMS, EC_WAIT_FOREVER);
+#endif
 
 #ifdef CONFIG_THERMAL_MANAGEMENT
 const uint32_t thermal_thrd_period = 250;
@@ -99,17 +107,25 @@ static struct task_info tasks[] = {
 	  .tagname = "POST" },
 #endif
 
+#if CONFIG_PERIPHERAL_MANAGEMENT
 	{ .thread_id = periph_thrd_id, .can_suspend = false,
 	  .tagname = "PERIPH" },
+#endif
 
+#ifdef CONFIG_PWRMGMT
 	{ .thread_id = pwrseq_thrd_id, .can_suspend = true,
 	  .tagname = "PWR" },
+#endif
 
+#ifdef CONFIG_ESPI
 	{ .thread_id = oobmngr_thrd_id, .can_suspend = false,
 	  .tagname = "OOB" },
+#endif
 
+#ifdef CONFIG_SMCHOST
 	{ .thread_id = smchost_thrd_id, .can_suspend = false,
 	  .tagname = "SMC" },
+#endif
 
 #ifdef CONFIG_THERMAL_MANAGEMENT
 	{ .thread_id = thermal_thrd_id, .can_suspend = false,


### PR DESCRIPTION
distinguish CONFIG of app to avoid build error if one of CONFIG of app disabled.

CONFIG of app :
1. CONFIG_PERIPHERAL_MANAGEMENT
2. CONFIG_PWRMGMT
3. CONFIG_DNX_SUPPORT
4. CONFIG_SOC_DEBUG_AWARENESS
5. CONFIG_SMCHOST
6. CONFIG_POSTCODE_MANAGEMENT 
7. CONFIG_ESPI_PERIPHERAL_8042_KBC 
8. CONFIG_ESPI_SAF 
9. CONFIG_SAF_SPI_WINBOND

Signed-off-by: Richard Yim <richardyim@ami.com>  