### PR TITLE
boards : migrate kconfig value

### DIFF
--- a/boards/mec1501_adl.conf
+++ b/boards/mec1501_adl.conf
@@ -13,6 +13,12 @@ CONFIG_DEPRECATED_HW_STRAP_BASED_PECI_MODE_SEL=y
 # Support deprecated SMChost commands for backward compatibility
 CONFIG_DEPRECATED_SMCHOST_CMD=y
 
+CONFIG_SAF_SPI_CAPACITY=32
+
+# Zephyr kernel/driver configuration required by EC FW
+# ----------------------------------------------------
+CONFIG_SOC_MEC1501_VCI_PINS_AS_GPIOS=y
+
 # Soc-specific configuration
 # --------------------------
 # Main clock is derived from external crystal

--- a/boards/mec1501_adl_p.conf
+++ b/boards/mec1501_adl_p.conf
@@ -16,8 +16,12 @@ CONFIG_SOC_DEBUG_CONSENT_GPIO=y
 # Support deprecated SMChost commands for backward compatibility
 CONFIG_DEPRECATED_SMCHOST_CMD=y
 
+CONFIG_SAF_SPI_CAPACITY=32
+
 # Zephyr kernel/driver configuration required by EC FW
 # ----------------------------------------------------
+CONFIG_SOC_MEC1501_VCI_PINS_AS_GPIOS=y
+
 # Enable additional drivers for ADL-P
 CONFIG_PS2=y
 

--- a/boards/mec1501modular_assy6885.conf
+++ b/boards/mec1501modular_assy6885.conf
@@ -28,7 +28,7 @@ CONFIG_DEPRECATED_SMCHOST_CMD=y
 
 # Zephyr kernel/driver configuration required by EC FW
 # ----------------------------------------------------
-CONFIG_SAF_SPI_CAPACITY=16
+CONFIG_SOC_MEC1501_VCI_PINS_AS_GPIOS=y
 
 # Enable PECI driver for thermal
 CONFIG_PECI=y

--- a/prj.conf
+++ b/prj.conf
@@ -17,7 +17,6 @@ CONFIG_OOBMNGR_SUPPORT=y
 
 # Zephyr kernel/driver configuration required by EC FW
 # ----------------------------------------------------
-CONFIG_SOC_MEC1501_VCI_PINS_AS_GPIOS=y
 CONFIG_WATCHDOG=y
 
 # EC FW flows require to intercept host warnings
@@ -35,7 +34,6 @@ CONFIG_ESPI_FLASH_CHANNEL=y
 # SAF required drivers
 CONFIG_SPI=y
 CONFIG_ESPI_SAF=y
-CONFIG_SAF_SPI_CAPACITY=32
 
 # Kernel debug features
 # ---------------------


### PR DESCRIPTION
migrate MEC related CONFIG into where those the board belong. This can avoid Cmake failed to generate CONFIG in configuration phase when board selected other than MEC.

Signed-off-by: Richard Yim <richardyim@ami.com> 