### PR TITLE
app: fix virtual wire enum declaration

### DIFF
--- a/drivers/espi_hub.c
+++ b/drivers/espi_hub.c
@@ -526,7 +526,7 @@ int wait_for_pin_monitor_vwire(uint32_t port_pin, uint32_t exp_sts,
 }
 
 int espihub_retrieve_vw(enum espi_vwire_signal signal,
-			enum espihub_vw_level *level)
+			uint8_t *level)
 {
 	if (!hub.host_vw_ready) {
 		LOG_ERR("eSPI host not ready to receive VWs");

--- a/drivers/espi_hub.h
+++ b/drivers/espi_hub.h
@@ -240,7 +240,7 @@ int espihub_add_postcode_handler(espi_postcode_handler_t handler);
  * @retval -EINVAL if eSPI channel is not ready or 0 if success.
  */
 int espihub_retrieve_vw(enum espi_vwire_signal signal,
-			enum espihub_vw_level *level);
+			uint8_t *level);
 
 /**
  * @brief Send a virtual wire ensuring the eSPI channel is ready.


### PR DESCRIPTION
fix build error from other EC platform by replace local variable of  data type to `enum espihub_vw_level`. Build with other than MEC board will displayed build error by incompatible pointer type.

```
error: passing argument 2 of 'espihub_retrieve_vw' from incompatible pointer type [-Werror=incompatible-pointer-types]
  110 |  ret = espihub_retrieve_vw(ESPI_VWIRE_SIGNAL_DNX_WARN, &vw_level);
      |                                                        ^~~~~~~~~
      |                                                        |
      |                                                        uint8_t * {aka unsigned char *}
```