### PR TITLE
zephyr_patches: remove IRQn_Type from MEC172X

### DIFF
--- a/zephyr_patches/zephyr_v2_7_oe_1_65.patch
+++ b/zephyr_patches/zephyr_v2_7_oe_1_65.patch
@@ -1,7 +1,7 @@
-From 7fb98d6447fd4803b66c5ea391b8f3445dfb4c14 Mon Sep 17 00:00:00 2001
+From 5524f7d7cee80fd6f929761e472b75762cda0160 Mon Sep 17 00:00:00 2001
 From: Venkataramana Kotakonda <venkataramana.kotakonda@intel.com>
 Date: Mon, 30 Mar 2020 10:32:05 -0400
-Subject: [PATCH 001/112] drivers: espi: Clear virtual wire interrupt before
+Subject: [PATCH 001/111] drivers: espi: Clear virtual wire interrupt before
  calling handler
 
 Clearing virtual wire interrupt after calling handler may cause next
@@ -16,7 +16,7 @@ Signed-off-by: Venkataramana Kotakonda <venkataramana.kotakonda@intel.com>
  1 file changed, 1 insertion(+), 2 deletions(-)
 
 diff --git a/drivers/espi/espi_mchp_xec.c b/drivers/espi/espi_mchp_xec.c
-index 51517d534a..ff15097560 100644
+index 51517d534..ff1509756 100644
 --- a/drivers/espi/espi_mchp_xec.c
 +++ b/drivers/espi/espi_mchp_xec.c
 @@ -1327,6 +1327,7 @@ static void espi_xec_vw_isr(const struct device *dev)
@@ -37,13 +37,13 @@ index 51517d534a..ff15097560 100644
  
  #if DT_INST_PROP_HAS_IDX(0, vw_girqs, 1)
 -- 
-2.17.1
+2.25.1
 
 
-From 611d9d355e880c8476d72bdaf8ee7e0fe92bdbf7 Mon Sep 17 00:00:00 2001
+From aff211dd6040220954d82ded706625d3e4b66614 Mon Sep 17 00:00:00 2001
 From: Jose Alberto Meza <jose.a.meza.arellano@intel.com>
 Date: Wed, 9 Sep 2020 12:02:49 -0700
-Subject: [PATCH 002/112] build: Trigger app build when Zephyr is updated
+Subject: [PATCH 002/111] build: Trigger app build when Zephyr is updated
 
 Wait after build is triggered
 
@@ -55,7 +55,7 @@ Signed-off-by: Jose Alberto Meza <jose.a.meza.arellano@intel.com>
 
 diff --git a/.gitlab-ci.yml b/.gitlab-ci.yml
 new file mode 100644
-index 0000000000..28f4da425b
+index 000000000..28f4da425
 --- /dev/null
 +++ b/.gitlab-ci.yml
 @@ -0,0 +1,37 @@
@@ -97,13 +97,13 @@ index 0000000000..28f4da425b
 +  dependencies:
 +  - build
 -- 
-2.17.1
+2.25.1
 
 
-From 99fc263f82f31ad447ba04bdb68aa16a4230ad1e Mon Sep 17 00:00:00 2001
+From 0bb8c0105936bfa13745495fc75ea88dd49812a9 Mon Sep 17 00:00:00 2001
 From: Jose Alberto Meza <jose.a.meza.arellano@intel.com>
 Date: Wed, 30 Dec 2020 14:20:40 -0800
-Subject: [PATCH 003/112] drivers: peci: xec: Handle corner case for PECI
+Subject: [PATCH 003/111] drivers: peci: xec: Handle corner case for PECI
  recovery
 
 Handle case where PECI recovery occurs in ISR context.
@@ -114,7 +114,7 @@ Signed-off-by: Jose Alberto Meza <jose.a.meza.arellano@intel.com>
  1 file changed, 9 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/peci/peci_mchp_xec.c b/drivers/peci/peci_mchp_xec.c
-index 9a2d76f74c..19a2020f42 100644
+index 9a2d76f74..19a2020f4 100644
 --- a/drivers/peci/peci_mchp_xec.c
 +++ b/drivers/peci/peci_mchp_xec.c
 @@ -17,6 +17,7 @@ LOG_MODULE_REGISTER(peci_mchp_xec, CONFIG_PECI_LOG_LEVEL);
@@ -150,13 +150,13 @@ index 9a2d76f74c..19a2020f42 100644
  
  #ifdef CONFIG_PECI_INTERRUPT_DRIVEN
 -- 
-2.17.1
+2.25.1
 
 
-From ae5cafa23265ac7cf1a30177c753a69ab8a3379b Mon Sep 17 00:00:00 2001
+From f8ce7bf01e9189081c13f5278722199ef3a5760b Mon Sep 17 00:00:00 2001
 From: Rajavardhan Gundi <rajavardhan.gundi@intel.com>
 Date: Wed, 27 Jan 2021 19:18:55 +0530
-Subject: [PATCH 004/112] drivers: pwm: xec: Add pwm led capability
+Subject: [PATCH 004/111] drivers: pwm: xec: Add pwm led capability
 
 Signed-off-by: Rajavardhan Gundi <rajavardhan.gundi@intel.com>
 ---
@@ -164,7 +164,7 @@ Signed-off-by: Rajavardhan Gundi <rajavardhan.gundi@intel.com>
  1 file changed, 6 insertions(+)
 
 diff --git a/dts/bindings/pwm/microchip,xec-pwm.yaml b/dts/bindings/pwm/microchip,xec-pwm.yaml
-index 630b4a3129..4a292968fb 100644
+index 630b4a312..4a292968f 100644
 --- a/dts/bindings/pwm/microchip,xec-pwm.yaml
 +++ b/dts/bindings/pwm/microchip,xec-pwm.yaml
 @@ -13,3 +13,9 @@ properties:
@@ -178,13 +178,13 @@ index 630b4a3129..4a292968fb 100644
 +pwm-cells:
 +  - channel
 -- 
-2.17.1
+2.25.1
 
 
-From f1aab59f16310d9a6b8cf0f2d1a48b567bea8d2d Mon Sep 17 00:00:00 2001
+From 4f5e7a871bb38a74a882e07547a03c1ffbcb75dc Mon Sep 17 00:00:00 2001
 From: Diwakar C <diwakar.c@intel.com>
 Date: Wed, 27 Jan 2021 01:07:58 +0530
-Subject: [PATCH 005/112] peci: driver: Reset Tx/Rx FIFOs after every
+Subject: [PATCH 005/111] peci: driver: Reset Tx/Rx FIFOs after every
  successful peci tx
 
 In the current implementation, FW reads FCS only for the commands
@@ -212,7 +212,7 @@ Signed-off-by: Diwakar C <diwakar.c@intel.com>
  1 file changed, 3 insertions(+)
 
 diff --git a/drivers/peci/peci_mchp_xec.c b/drivers/peci/peci_mchp_xec.c
-index 19a2020f42..519ab20518 100644
+index 19a2020f4..519ab2051 100644
 --- a/drivers/peci/peci_mchp_xec.c
 +++ b/drivers/peci/peci_mchp_xec.c
 @@ -337,6 +337,9 @@ static int peci_xec_transfer(const struct device *dev, struct peci_msg *msg)
@@ -226,13 +226,13 @@ index 19a2020f42..519ab20518 100644
  }
  
 -- 
-2.17.1
+2.25.1
 
 
-From 6e4d27f2c3a5e13a965da7a72f04f6fa965ac1db Mon Sep 17 00:00:00 2001
+From d75d43f1fb1074905781d20d211a95c5bb47fa51 Mon Sep 17 00:00:00 2001
 From: Rajavardhan Gundi <rajavardhan.gundi@intel.com>
 Date: Sun, 31 Jan 2021 23:20:44 +0530
-Subject: [PATCH 006/112] Revert "boards: mec1501modular: build without image
+Subject: [PATCH 006/111] Revert "boards: mec1501modular: build without image
  gen tool"
 
 This reverts commit 209e4ee1a14a86ab03b6c32bec2f56412f43d068.
@@ -242,7 +242,7 @@ It breaks the "spi_gen utility find" functionality.
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/boards/arm/mec1501modular_assy6885/CMakeLists.txt b/boards/arm/mec1501modular_assy6885/CMakeLists.txt
-index f96a887b05..7b0c4c7898 100644
+index f96a887b0..7b0c4c789 100644
 --- a/boards/arm/mec1501modular_assy6885/CMakeLists.txt
 +++ b/boards/arm/mec1501modular_assy6885/CMakeLists.txt
 @@ -24,7 +24,7 @@ else()
@@ -255,13 +255,13 @@ index f96a887b05..7b0c4c7898 100644
      message(WARNING "Microchip SPI Image Generation tool (${EVERGLADES_SPI_GEN_FILENAME}) is not available. SPI Image will not be generated.")
    else()
 -- 
-2.17.1
+2.25.1
 
 
-From 97c7677768c316c6f16202645f70046cf9faca5a Mon Sep 17 00:00:00 2001
+From 10bf35a6c86ade5bacf52d55b1d0de70f99f0850 Mon Sep 17 00:00:00 2001
 From: Jose Alberto Meza <jose.a.meza.arellano@intel.com>
 Date: Mon, 1 Feb 2021 10:11:17 -0800
-Subject: [PATCH 007/112] soc: arm: mchp: Remove magic numbers
+Subject: [PATCH 007/111] soc: arm: mchp: Remove magic numbers
 
 Add SoC MEC150x device ID macros.
 
@@ -271,7 +271,7 @@ Signed-off-by: Jose Alberto Meza <jose.a.meza.arellano@intel.com>
  1 file changed, 5 insertions(+), 2 deletions(-)
 
 diff --git a/soc/arm/microchip_mec/mec1501/soc.c b/soc/arm/microchip_mec/mec1501/soc.c
-index a315ef1dd0..10f34bde7f 100644
+index a315ef1dd..10f34bde7 100644
 --- a/soc/arm/microchip_mec/mec1501/soc.c
 +++ b/soc/arm/microchip_mec/mec1501/soc.c
 @@ -11,6 +11,9 @@
@@ -297,13 +297,13 @@ index a315ef1dd0..10f34bde7f 100644
  	}
  
 -- 
-2.17.1
+2.25.1
 
 
-From 1e23653ec2e1a388c481d91af68339758d3406e7 Mon Sep 17 00:00:00 2001
+From 4a45f244fade67aeff780c6bd654c66cfbdab456 Mon Sep 17 00:00:00 2001
 From: Jose Alberto Meza <jose.a.meza.arellano@intel.com>
 Date: Wed, 12 Aug 2020 11:10:51 -0700
-Subject: [PATCH 008/112] drivers: espi_saf: xec: Instrument eSPI SAF driver
+Subject: [PATCH 008/111] drivers: espi_saf: xec: Instrument eSPI SAF driver
  for debug
 
 Add traces for common error cases.
@@ -316,7 +316,7 @@ Signed-off-by: Jose Alberto Meza <jose.a.meza.arellano@intel.com>
  1 file changed, 19 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/espi/espi_saf_mchp_xec.c b/drivers/espi/espi_saf_mchp_xec.c
-index 674a4948f9..950340f4ae 100644
+index 674a4948f..950340f4a 100644
 --- a/drivers/espi/espi_saf_mchp_xec.c
 +++ b/drivers/espi/espi_saf_mchp_xec.c
 @@ -20,8 +20,8 @@ LOG_MODULE_REGISTER(espi_saf, CONFIG_ESPI_LOG_LEVEL);
@@ -412,13 +412,13 @@ index 674a4948f9..950340f4ae 100644
  	/* optional second flash device connected to CS1 */
  	if (cfg->nflash_devices > 1) {
 -- 
-2.17.1
+2.25.1
 
 
-From 718457e7b5c475a62ced689e3f921ba38a7d24ca Mon Sep 17 00:00:00 2001
+From 502edd1e7f789eccbed847a0ee4e68b5ad9d6a28 Mon Sep 17 00:00:00 2001
 From: Kunal Shah <kunal.a.shah@intel.com>
 Date: Wed, 3 Mar 2021 17:06:31 +0530
-Subject: [PATCH 009/112] espi:driver: espi ltr support
+Subject: [PATCH 009/111] espi:driver: espi ltr support
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -441,7 +441,7 @@ Signed-off-by: Kunal Shah <kunal.a.shah@intel.com>
  2 files changed, 106 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/espi/espi_mchp_xec.c b/drivers/espi/espi_mchp_xec.c
-index ff15097560..b5acec1852 100644
+index ff1509756..b5acec185 100644
 --- a/drivers/espi/espi_mchp_xec.c
 +++ b/drivers/espi/espi_mchp_xec.c
 @@ -419,7 +419,26 @@ static int espi_xec_write_lpc_request(const struct device *dev,
@@ -519,7 +519,7 @@ index ff15097560..b5acec1852 100644
  	/* Enable VWires interrupts */
  	for (int i = 0; i < sizeof(vw_wires_int_en); i++) {
 diff --git a/include/drivers/espi.h b/include/drivers/espi.h
-index 7bbeeb4426..f8df492de5 100644
+index 7bbeeb442..f8df492de 100644
 --- a/include/drivers/espi.h
 +++ b/include/drivers/espi.h
 @@ -115,6 +115,30 @@ enum espi_bus_event {
@@ -628,13 +628,13 @@ index 7bbeeb4426..f8df492de5 100644
   * @brief Sends system/platform signal as a virtual wire packet.
   *
 -- 
-2.17.1
+2.25.1
 
 
-From 9fd2267e848102dbc65bbcf31f1a01268991f6be Mon Sep 17 00:00:00 2001
+From f9ef7a53aa909da63b25fd622d2a848d8a0e8a43 Mon Sep 17 00:00:00 2001
 From: Diwakar C <diwakar.c@intel.com>
 Date: Wed, 17 Feb 2021 20:21:11 +0530
-Subject: [PATCH 010/112] espi: driver: Config spare espi vw register to OCP
+Subject: [PATCH 010/111] espi: driver: Config spare espi vw register to OCP
  index
 
 USBC port (port 0/1/2/3) OCP (Over Current Protection) status should
@@ -651,7 +651,7 @@ Signed-off-by: Diwakar C <diwakar.c@intel.com>
  2 files changed, 47 insertions(+)
 
 diff --git a/drivers/espi/espi_mchp_xec.c b/drivers/espi/espi_mchp_xec.c
-index b5acec1852..7452819b5b 100644
+index b5acec185..7452819b5 100644
 --- a/drivers/espi/espi_mchp_xec.c
 +++ b/drivers/espi/espi_mchp_xec.c
 @@ -55,6 +55,9 @@
@@ -732,7 +732,7 @@ index b5acec1852..7452819b5b 100644
  
  static void vw_oob_rst_isr(const struct device *dev)
 diff --git a/include/drivers/espi.h b/include/drivers/espi.h
-index f8df492de5..4839c2473a 100644
+index f8df492de..4839c2473 100644
 --- a/include/drivers/espi.h
 +++ b/include/drivers/espi.h
 @@ -239,6 +239,11 @@ enum espi_vwire_signal {
@@ -748,13 +748,13 @@ index f8df492de5..4839c2473a 100644
  
  /* eSPI LPC peripherals. */
 -- 
-2.17.1
+2.25.1
 
 
-From 5c13bd45e81d530268bb9fd3e53feb50633d366c Mon Sep 17 00:00:00 2001
+From 6ad63360e2b24aa96cb7257bfdd4ffb23d81af2d Mon Sep 17 00:00:00 2001
 From: Rajavardhan Gundi <rajavardhan.gundi@intel.com>
 Date: Mon, 9 Aug 2021 12:35:25 +0530
-Subject: [PATCH 011/112] drivers: i2c: Mchp: Use GPIO driver to read SCL/SDA
+Subject: [PATCH 011/111] drivers: i2c: Mchp: Use GPIO driver to read SCL/SDA
  state
 
 I2C bit-bang control register should not be used to read pin
@@ -773,7 +773,7 @@ Signed-off-by: Rajavardhan Gundi <rajavardhan.gundi@intel.com>
  5 files changed, 92 insertions(+), 7 deletions(-)
 
 diff --git a/boards/arm/mec1501modular_assy6885/mec1501modular_assy6885.dts b/boards/arm/mec1501modular_assy6885/mec1501modular_assy6885.dts
-index 4457bf018b..ad67ed0894 100644
+index 4457bf018..ad67ed089 100644
 --- a/boards/arm/mec1501modular_assy6885/mec1501modular_assy6885.dts
 +++ b/boards/arm/mec1501modular_assy6885/mec1501modular_assy6885.dts
 @@ -60,12 +60,16 @@
@@ -794,7 +794,7 @@ index 4457bf018b..ad67ed0894 100644
  
  &espi0 {
 diff --git a/boards/arm/mec1501modular_assy6885/mec1501modular_assy6885_defconfig b/boards/arm/mec1501modular_assy6885/mec1501modular_assy6885_defconfig
-index 9818b0c11f..49e269f91d 100644
+index 9818b0c11..49e269f91 100644
 --- a/boards/arm/mec1501modular_assy6885/mec1501modular_assy6885_defconfig
 +++ b/boards/arm/mec1501modular_assy6885/mec1501modular_assy6885_defconfig
 @@ -23,6 +23,7 @@ CONFIG_PWM=y
@@ -806,7 +806,7 @@ index 9818b0c11f..49e269f91d 100644
  CONFIG_ESPI_PERIPHERAL_UART_SOC_MAPPING=1
  
 diff --git a/boards/arm/mec15xxevb_assy6853/mec15xxevb_assy6853.dts b/boards/arm/mec15xxevb_assy6853/mec15xxevb_assy6853.dts
-index 510544a2e5..ce0c621980 100644
+index 510544a2e..ce0c62198 100644
 --- a/boards/arm/mec15xxevb_assy6853/mec15xxevb_assy6853.dts
 +++ b/boards/arm/mec15xxevb_assy6853/mec15xxevb_assy6853.dts
 @@ -87,6 +87,8 @@
@@ -836,7 +836,7 @@ index 510544a2e5..ce0c621980 100644
  
  &espi0 {
 diff --git a/drivers/i2c/i2c_mchp_xec.c b/drivers/i2c/i2c_mchp_xec.c
-index 26952ef105..81cbf5b758 100644
+index 26952ef10..81cbf5b75 100644
 --- a/drivers/i2c/i2c_mchp_xec.c
 +++ b/drivers/i2c/i2c_mchp_xec.c
 @@ -10,6 +10,7 @@
@@ -983,7 +983,7 @@ index 26952ef105..81cbf5b758 100644
  	};								\
  	DEVICE_DT_INST_DEFINE(n, &i2c_xec_init, NULL,			\
 diff --git a/dts/bindings/i2c/microchip,xec-i2c.yaml b/dts/bindings/i2c/microchip,xec-i2c.yaml
-index dcd22bd468..f8a78abd59 100644
+index dcd22bd46..f8a78abd5 100644
 --- a/dts/bindings/i2c/microchip,xec-i2c.yaml
 +++ b/dts/bindings/i2c/microchip,xec-i2c.yaml
 @@ -25,3 +25,18 @@ properties:
@@ -1006,13 +1006,13 @@ index dcd22bd468..f8a78abd59 100644
 +        determined by chip and package.
 +
 -- 
-2.17.1
+2.25.1
 
 
-From b545bbed091ffbdfdf7f09d5267da090e10a11a3 Mon Sep 17 00:00:00 2001
+From 279b1858b3bfb30c38c78067ceb246573632d44d Mon Sep 17 00:00:00 2001
 From: Scott Worley <scott.worley@microchip.com>
 Date: Thu, 3 Jun 2021 18:27:59 -0400
-Subject: [PATCH 012/112] drivers: i2c: mchp: Fix driver NACK policy
+Subject: [PATCH 012/111] drivers: i2c: mchp: Fix driver NACK policy
 
 If the I2C controller receives a NACK from the target
 it should not reset the device. The I2C controller should
@@ -1027,7 +1027,7 @@ Signed-off-by: Scott Worley <scott.worley@microchip.com>
  1 file changed, 53 insertions(+), 18 deletions(-)
 
 diff --git a/drivers/i2c/i2c_mchp_xec.c b/drivers/i2c/i2c_mchp_xec.c
-index 81cbf5b758..524ea37e45 100644
+index 81cbf5b75..524ea37e4 100644
 --- a/drivers/i2c/i2c_mchp_xec.c
 +++ b/drivers/i2c/i2c_mchp_xec.c
 @@ -21,6 +21,7 @@ LOG_MODULE_REGISTER(i2c_mchp, CONFIG_I2C_LOG_LEVEL);
@@ -1127,13 +1127,13 @@ index 81cbf5b758..524ea37e45 100644
  
  	return 0;
 -- 
-2.17.1
+2.25.1
 
 
-From c0132c1be755ef04e875aa90b5ccfaf800e65500 Mon Sep 17 00:00:00 2001
+From 1e6a87c4cb5339421c4719636fb42ede71e55d92 Mon Sep 17 00:00:00 2001
 From: Rajavardhan Gundi <rajavardhan.gundi@intel.com>
 Date: Mon, 9 Aug 2021 13:56:47 +0530
-Subject: [PATCH 013/112] drivers: i2c: mchp: Fix controller hang during
+Subject: [PATCH 013/111] drivers: i2c: mchp: Fix controller hang during
  recovery
 
 Recovery should not be attempted when one of the CLK/DATA
@@ -1147,7 +1147,7 @@ Signed-off-by: Rajavardhan Gundi <rajavardhan.gundi@intel.com>
  1 file changed, 71 insertions(+), 17 deletions(-)
 
 diff --git a/drivers/i2c/i2c_mchp_xec.c b/drivers/i2c/i2c_mchp_xec.c
-index 524ea37e45..dedc8fca13 100644
+index 524ea37e4..dedc8fca1 100644
 --- a/drivers/i2c/i2c_mchp_xec.c
 +++ b/drivers/i2c/i2c_mchp_xec.c
 @@ -23,10 +23,14 @@ LOG_MODULE_REGISTER(i2c_mchp, CONFIG_I2C_LOG_LEVEL);
@@ -1371,13 +1371,13 @@ index 524ea37e45..dedc8fca13 100644
  	}
  
 -- 
-2.17.1
+2.25.1
 
 
-From eab5918cb84c19d5a84215feef250175306347b4 Mon Sep 17 00:00:00 2001
+From 00470c4300626ad8d5bf4cc3cd831a8415b610e3 Mon Sep 17 00:00:00 2001
 From: Rajavardhan Gundi <rajavardhan.gundi@intel.com>
 Date: Thu, 19 Aug 2021 20:49:02 +0530
-Subject: [PATCH 014/112] drivers: i2c: mchp: Fix NAK handling
+Subject: [PATCH 014/111] drivers: i2c: mchp: Fix NAK handling
 
 If NAK is received for an address, it just means the slave is
 not present. If NAK is received for data, it means the reader
@@ -1390,7 +1390,7 @@ Signed-off-by: Rajavardhan Gundi <rajavardhan.gundi@intel.com>
  1 file changed, 36 insertions(+), 9 deletions(-)
 
 diff --git a/drivers/i2c/i2c_mchp_xec.c b/drivers/i2c/i2c_mchp_xec.c
-index dedc8fca13..d2a7463fad 100644
+index dedc8fca1..d2a7463fa 100644
 --- a/drivers/i2c/i2c_mchp_xec.c
 +++ b/drivers/i2c/i2c_mchp_xec.c
 @@ -416,9 +416,18 @@ static int i2c_xec_poll_write(const struct device *dev, struct i2c_msg msg,
@@ -1460,13 +1460,13 @@ index dedc8fca13..d2a7463fad 100644
  	}
  
 -- 
-2.17.1
+2.25.1
 
 
-From d0a9d3950c5fc542d3b5f14e7288a322f1bee388 Mon Sep 17 00:00:00 2001
+From b87e3769f90c4976a5c96d69c6ea3e2408b68711 Mon Sep 17 00:00:00 2001
 From: Rajavardhan Gundi <rajavardhan.gundi@intel.com>
 Date: Tue, 12 Oct 2021 12:21:53 +0530
-Subject: [PATCH 015/112] drivers: i2c: mchp: Fix Timeout errors
+Subject: [PATCH 015/111] drivers: i2c: mchp: Fix Timeout errors
 
 When a slave stretches the clock beyond the permissible limit
 set in the driver, a timeout occurs post which the master deems
@@ -1480,7 +1480,7 @@ Signed-off-by: Rajavardhan Gundi <rajavardhan.gundi@intel.com>
  1 file changed, 147 insertions(+), 64 deletions(-)
 
 diff --git a/drivers/i2c/i2c_mchp_xec.c b/drivers/i2c/i2c_mchp_xec.c
-index d2a7463fad..e40efc2cb0 100644
+index d2a7463fa..e40efc2cb 100644
 --- a/drivers/i2c/i2c_mchp_xec.c
 +++ b/drivers/i2c/i2c_mchp_xec.c
 @@ -62,6 +62,8 @@ struct i2c_xec_config {
@@ -1763,13 +1763,13 @@ index d2a7463fad..e40efc2cb0 100644
  
  		if (i == (msg.len - 1)) {
 -- 
-2.17.1
+2.25.1
 
 
-From cd7c6a3996f483c0057c2e27df3438415f47d40f Mon Sep 17 00:00:00 2001
+From 9c7124f3b0e7e04d468aab198be7a0535618209b Mon Sep 17 00:00:00 2001
 From: Aditya Bhutada <aditya.bhutada@intel.com>
 Date: Fri, 10 Dec 2021 14:13:49 -0800
-Subject: [PATCH 016/112] dts: bindings: adc: microchip: Introduced clk_time
+Subject: [PATCH 016/111] dts: bindings: adc: microchip: Introduced clk_time
  field
 
 Added clk_time field to configure Microchip ADC config register.
@@ -1783,7 +1783,7 @@ Signed-off-by: Aditya Bhutada <aditya.bhutada@intel.com>
  2 files changed, 6 insertions(+)
 
 diff --git a/dts/arm/microchip/mec1501hsz.dtsi b/dts/arm/microchip/mec1501hsz.dtsi
-index 2a6c4b2dc1..5a10c73142 100644
+index 2a6c4b2dc..5a10c7314 100644
 --- a/dts/arm/microchip/mec1501hsz.dtsi
 +++ b/dts/arm/microchip/mec1501hsz.dtsi
 @@ -400,6 +400,7 @@
@@ -1795,7 +1795,7 @@ index 2a6c4b2dc1..5a10c73142 100644
  		kscan0: kscan@40009c00 {
  			compatible = "microchip,xec-kscan";
 diff --git a/dts/bindings/adc/microchip,xec-adc.yaml b/dts/bindings/adc/microchip,xec-adc.yaml
-index 4e059b5580..6d8216b7d6 100644
+index 4e059b558..6d8216b7d 100644
 --- a/dts/bindings/adc/microchip,xec-adc.yaml
 +++ b/dts/bindings/adc/microchip,xec-adc.yaml
 @@ -17,5 +17,10 @@ properties:
@@ -1810,13 +1810,13 @@ index 4e059b5580..6d8216b7d6 100644
  io-channel-cells:
      - input
 -- 
-2.17.1
+2.25.1
 
 
-From cf704bb0847695cc075a2d0cdbf8e0059238e3d9 Mon Sep 17 00:00:00 2001
+From 203e4ac6ec8074e56c2447a959c0b3eb013d03e0 Mon Sep 17 00:00:00 2001
 From: Aditya Bhutada <aditya.bhutada@intel.com>
 Date: Fri, 10 Dec 2021 14:21:31 -0800
-Subject: [PATCH 017/112] drivers: adc: adc_mchp_xec: update configuration
+Subject: [PATCH 017/111] drivers: adc: adc_mchp_xec: update configuration
  register clk times
 
 MCHP ADC configuration register need to be updated with appropriate
@@ -1828,7 +1828,7 @@ Signed-off-by: Aditya Bhutada <aditya.bhutada@intel.com>
  1 file changed, 7 insertions(+)
 
 diff --git a/drivers/adc/adc_mchp_xec.c b/drivers/adc/adc_mchp_xec.c
-index 704450f043..1db325959d 100644
+index 704450f04..1db325959 100644
 --- a/drivers/adc/adc_mchp_xec.c
 +++ b/drivers/adc/adc_mchp_xec.c
 @@ -278,11 +278,18 @@ struct adc_driver_api adc_xec_api = {
@@ -1851,13 +1851,13 @@ index 704450f043..1db325959d 100644
  		| XEC_ADC_CTRL_POWER_SAVER_DIS
  		| XEC_ADC_CTRL_SINGLE_DONE_STATUS
 -- 
-2.17.1
+2.25.1
 
 
-From 548b417869668d447551f24d793d02615a319597 Mon Sep 17 00:00:00 2001
+From e2a584c1e444d3a0deb574110528dcb1dc3bc3b0 Mon Sep 17 00:00:00 2001
 From: Rajavardhan Gundi <rajavardhan.gundi@intel.com>
 Date: Thu, 27 Jan 2022 12:34:57 +0530
-Subject: [PATCH 018/112] drivers: i2c: mchp: Address NAK in i2c_read
+Subject: [PATCH 018/111] drivers: i2c: mchp: Address NAK in i2c_read
  appropriately
 
 Normally, i2c writes always precede i2c reads. So, address
@@ -1871,7 +1871,7 @@ Signed-off-by: Rajavardhan Gundi <rajavardhan.gundi@intel.com>
  1 file changed, 1 insertion(+)
 
 diff --git a/drivers/i2c/i2c_mchp_xec.c b/drivers/i2c/i2c_mchp_xec.c
-index e40efc2cb0..a6aa1c69fb 100644
+index e40efc2cb..a6aa1c69f 100644
 --- a/drivers/i2c/i2c_mchp_xec.c
 +++ b/drivers/i2c/i2c_mchp_xec.c
 @@ -593,6 +593,7 @@ static int i2c_xec_poll_read(const struct device *dev, struct i2c_msg msg,
@@ -1883,14 +1883,14 @@ index e40efc2cb0..a6aa1c69fb 100644
  			__func__, addr >> 1, dev->name);
  		return ret;
 -- 
-2.17.1
+2.25.1
 
 
-From 938a96d7b33e2daf48f1bb5cbc0e8285491ee2d2 Mon Sep 17 00:00:00 2001
+From 712c6d4620f9bb1154127ad387fad49b8e5bf9c4 Mon Sep 17 00:00:00 2001
 From: Jose Alberto Meza <jose.a.meza.arellano@intel.com>
 Date: Mon, 14 Feb 2022 11:16:30 -0800
-Subject: [PATCH 019/112] [BACPORTED] boards: arm: mec172xevb_assy6906: Reduce
- SPI image size
+Subject: [PATCH 019/111] boards: arm: mec172xevb_assy6906: Reduce SPI image
+ size
 
 Reduce SPI size to maximum FLASH ram size supported
 This also speed up flashing process.
@@ -1901,7 +1901,7 @@ Signed-off-by: Jose Alberto Meza <jose.a.meza.arellano@intel.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/boards/arm/mec172xevb_assy6906/support/spi_cfg.txt b/boards/arm/mec172xevb_assy6906/support/spi_cfg.txt
-index 913cc394b4..99da7c0d62 100644
+index 913cc394b..99da7c0d6 100644
 --- a/boards/arm/mec172xevb_assy6906/support/spi_cfg.txt
 +++ b/boards/arm/mec172xevb_assy6906/support/spi_cfg.txt
 @@ -1,6 +1,6 @@
@@ -1913,13 +1913,13 @@ index 913cc394b4..99da7c0d62 100644
  FlshmapAddr = 0
  
 -- 
-2.17.1
+2.25.1
 
 
-From 205fb8137bd82bae1a75e807e8143c1f5e2a8768 Mon Sep 17 00:00:00 2001
+From 2c459cdc28ba8960913e3aa2b245061ef87dc64f Mon Sep 17 00:00:00 2001
 From: Jay Vasanth <jay.vasanth@microchip.com>
 Date: Mon, 18 Oct 2021 16:44:45 -0400
-Subject: [PATCH 020/112] [BACPORTED] Microchip: MEC172x: eSPI driver
+Subject: [PATCH 020/111] Microchip: MEC172x: eSPI driver
 
 MEC172x eSPI driver, eSPI pin programming, interrupt updates related
 to eSPI and other updates for MEC172x eSPI driver.
@@ -1962,7 +1962,7 @@ Signed-off-by: Jay Vasanth <jay.vasanth@microchip.com>
  create mode 100644 soc/arm/microchip_mec/common/soc_espi_v2.h
 
 diff --git a/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts b/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts
-index fb7c7231a3..c81159ad45 100644
+index fb7c7231a..c81159ad4 100644
 --- a/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts
 +++ b/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts
 @@ -54,6 +54,15 @@
@@ -2010,7 +2010,7 @@ index fb7c7231a3..c81159ad45 100644
  	status = "okay";
  	label = "I2C0";
 diff --git a/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906_defconfig b/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906_defconfig
-index 8c03840f5d..80eb72b962 100644
+index 8c03840f5..80eb72b96 100644
 --- a/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906_defconfig
 +++ b/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906_defconfig
 @@ -17,3 +17,4 @@ CONFIG_CONSOLE=y
@@ -2019,7 +2019,7 @@ index 8c03840f5d..80eb72b962 100644
  CONFIG_I2C=y
 +CONFIG_ESPI=y
 diff --git a/boards/arm/mec172xevb_assy6906/pinmux.c b/boards/arm/mec172xevb_assy6906/pinmux.c
-index 49aa3e3742..871fff3649 100644
+index 49aa3e374..871fff364 100644
 --- a/boards/arm/mec172xevb_assy6906/pinmux.c
 +++ b/boards/arm/mec172xevb_assy6906/pinmux.c
 @@ -7,10 +7,27 @@
@@ -2153,7 +2153,7 @@ index 49aa3e3742..871fff3649 100644
  	return 0;
  }
 diff --git a/drivers/espi/CMakeLists.txt b/drivers/espi/CMakeLists.txt
-index d26e50cbd1..5ba46d2615 100644
+index d26e50cbd..5ba46d261 100644
 --- a/drivers/espi/CMakeLists.txt
 +++ b/drivers/espi/CMakeLists.txt
 @@ -8,3 +8,5 @@ zephyr_library_sources_ifdef(CONFIG_ESPI_NPCX		host_subs_npcx.c)
@@ -2163,7 +2163,7 @@ index d26e50cbd1..5ba46d2615 100644
 +zephyr_library_sources_ifdef(CONFIG_ESPI_XEC_V2		espi_mchp_xec_v2.c)
 +zephyr_library_sources_ifdef(CONFIG_ESPI_XEC_V2		espi_mchp_xec_host_v2.c)
 diff --git a/drivers/espi/Kconfig b/drivers/espi/Kconfig
-index e74dc39e27..6a8c2ecac9 100644
+index e74dc39e2..6a8c2ecac 100644
 --- a/drivers/espi/Kconfig
 +++ b/drivers/espi/Kconfig
 @@ -12,6 +12,8 @@ if ESPI
@@ -2176,7 +2176,7 @@ index e74dc39e27..6a8c2ecac9 100644
  
  source "drivers/espi/Kconfig.espi_emul"
 diff --git a/drivers/espi/Kconfig.xec b/drivers/espi/Kconfig.xec
-index 6614a54a82..6ff528068b 100644
+index 6614a54a8..6ff528068 100644
 --- a/drivers/espi/Kconfig.xec
 +++ b/drivers/espi/Kconfig.xec
 @@ -5,9 +5,9 @@
@@ -2193,7 +2193,7 @@ index 6614a54a82..6ff528068b 100644
  
 diff --git a/drivers/espi/Kconfig.xec_v2 b/drivers/espi/Kconfig.xec_v2
 new file mode 100644
-index 0000000000..25a3c88a2c
+index 000000000..25a3c88a2
 --- /dev/null
 +++ b/drivers/espi/Kconfig.xec_v2
 @@ -0,0 +1,132 @@
@@ -2331,7 +2331,7 @@ index 0000000000..25a3c88a2c
 +endif #ESPI_XEC_V2
 diff --git a/drivers/espi/espi_mchp_xec_host_v2.c b/drivers/espi/espi_mchp_xec_host_v2.c
 new file mode 100644
-index 0000000000..a00e7f86d3
+index 000000000..a00e7f86d
 --- /dev/null
 +++ b/drivers/espi/espi_mchp_xec_host_v2.c
 @@ -0,0 +1,819 @@
@@ -3156,7 +3156,7 @@ index 0000000000..a00e7f86d3
 +#endif /* CONFIG_ESPI_PERIPHERAL_CHANNEL */
 diff --git a/drivers/espi/espi_mchp_xec_v2.c b/drivers/espi/espi_mchp_xec_v2.c
 new file mode 100644
-index 0000000000..016c39ed1a
+index 000000000..016c39ed1
 --- /dev/null
 +++ b/drivers/espi/espi_mchp_xec_v2.c
 @@ -0,0 +1,1387 @@
@@ -4549,7 +4549,7 @@ index 0000000000..016c39ed1a
 +}
 diff --git a/drivers/espi/espi_mchp_xec_v2.h b/drivers/espi/espi_mchp_xec_v2.h
 new file mode 100644
-index 0000000000..d984c39a50
+index 000000000..d984c39a5
 --- /dev/null
 +++ b/drivers/espi/espi_mchp_xec_v2.h
 @@ -0,0 +1,119 @@
@@ -4673,7 +4673,7 @@ index 0000000000..d984c39a50
 +
 +#endif /* ZEPHYR_DRIVERS_ESPI_MCHP_XEC_ESPI_V2_H_ */
 diff --git a/drivers/interrupt_controller/intc_mchp_ecia_xec.c b/drivers/interrupt_controller/intc_mchp_ecia_xec.c
-index b364945a0e..9f96f06d2d 100644
+index b364945a0..9f96f06d2 100644
 --- a/drivers/interrupt_controller/intc_mchp_ecia_xec.c
 +++ b/drivers/interrupt_controller/intc_mchp_ecia_xec.c
 @@ -19,6 +19,7 @@
@@ -4831,7 +4831,7 @@ index b364945a0e..9f96f06d2d 100644
   * We make use of DT FOREACH macro to check GIRQ node status.
 diff --git a/dts/arm/microchip/mec172x/mec172x-vw-routing.dtsi b/dts/arm/microchip/mec172x/mec172x-vw-routing.dtsi
 new file mode 100644
-index 0000000000..8d3439abec
+index 000000000..8d3439abe
 --- /dev/null
 +++ b/dts/arm/microchip/mec172x/mec172x-vw-routing.dtsi
 @@ -0,0 +1,114 @@
@@ -4950,7 +4950,7 @@ index 0000000000..8d3439abec
 +	};
 +};
 diff --git a/dts/arm/microchip/mec172xnsz.dtsi b/dts/arm/microchip/mec172xnsz.dtsi
-index f19e95cc4a..7a96a43dff 100644
+index f19e95cc4..7a96a43df 100644
 --- a/dts/arm/microchip/mec172xnsz.dtsi
 +++ b/dts/arm/microchip/mec172xnsz.dtsi
 @@ -11,6 +11,8 @@
@@ -5259,7 +5259,7 @@ index f19e95cc4a..7a96a43dff 100644
  
 diff --git a/dts/bindings/espi/microchip,xec-espi-host-dev.yaml b/dts/bindings/espi/microchip,xec-espi-host-dev.yaml
 new file mode 100644
-index 0000000000..db2c1385f1
+index 000000000..db2c1385f
 --- /dev/null
 +++ b/dts/bindings/espi/microchip,xec-espi-host-dev.yaml
 @@ -0,0 +1,95 @@
@@ -5360,7 +5360,7 @@ index 0000000000..db2c1385f1
 +    - bitpos
 diff --git a/dts/bindings/espi/microchip,xec-espi-v2.yaml b/dts/bindings/espi/microchip,xec-espi-v2.yaml
 new file mode 100644
-index 0000000000..563dc93a52
+index 000000000..563dc93a5
 --- /dev/null
 +++ b/dts/bindings/espi/microchip,xec-espi-v2.yaml
 @@ -0,0 +1,44 @@
@@ -5410,7 +5410,7 @@ index 0000000000..563dc93a52
 +    - bitpos
 diff --git a/dts/bindings/espi/microchip,xec-espi-vw-routing.yaml b/dts/bindings/espi/microchip,xec-espi-vw-routing.yaml
 new file mode 100644
-index 0000000000..e743994d8d
+index 000000000..e743994d8
 --- /dev/null
 +++ b/dts/bindings/espi/microchip,xec-espi-vw-routing.yaml
 @@ -0,0 +1,25 @@
@@ -5440,7 +5440,7 @@ index 0000000000..e743994d8d
 +            Example: OOB_RST_WARN is source 2 of MSVW01 routed to GIRQ24 b[5]
 +               vw-girq = <24 5>;
 diff --git a/dts/bindings/rtc/microchip,xec-timer.yaml b/dts/bindings/rtc/microchip,xec-timer.yaml
-index 0457d5a6e5..d391635b39 100644
+index 0457d5a6e..d391635b3 100644
 --- a/dts/bindings/rtc/microchip,xec-timer.yaml
 +++ b/dts/bindings/rtc/microchip,xec-timer.yaml
 @@ -37,7 +37,7 @@ properties:
@@ -5453,7 +5453,7 @@ index 0457d5a6e5..d391635b39 100644
        const: 2
  
 diff --git a/dts/bindings/serial/microchip,xec-uart.yaml b/dts/bindings/serial/microchip,xec-uart.yaml
-index 932ba026c3..fd05b7735e 100644
+index 932ba026c..fd05b7735 100644
 --- a/dts/bindings/serial/microchip,xec-uart.yaml
 +++ b/dts/bindings/serial/microchip,xec-uart.yaml
 @@ -11,6 +11,11 @@ properties:
@@ -5469,7 +5469,7 @@ index 932ba026c3..fd05b7735e 100644
        type: array
        required: true
 diff --git a/dts/bindings/timer/microchip,xec-rtos-timer.yaml b/dts/bindings/timer/microchip,xec-rtos-timer.yaml
-index 1175cf9b7f..30234e8249 100644
+index 1175cf9b7..30234e824 100644
 --- a/dts/bindings/timer/microchip,xec-rtos-timer.yaml
 +++ b/dts/bindings/timer/microchip,xec-rtos-timer.yaml
 @@ -22,7 +22,7 @@ properties:
@@ -5482,7 +5482,7 @@ index 1175cf9b7f..30234e8249 100644
        const: 2
  
 diff --git a/include/drivers/interrupt_controller/intc_mchp_xec_ecia.h b/include/drivers/interrupt_controller/intc_mchp_xec_ecia.h
-index e5093004a5..3214a6f97f 100644
+index e5093004a..3214a6f97 100644
 --- a/include/drivers/interrupt_controller/intc_mchp_xec_ecia.h
 +++ b/include/drivers/interrupt_controller/intc_mchp_xec_ecia.h
 @@ -28,6 +28,14 @@
@@ -5579,7 +5579,7 @@ index e5093004a5..3214a6f97f 100644
  #endif /* ZEPHYR_DRIVERS_INTERRUPT_CONTROLLER_MCHP_XEC_ECIA_H_ */
 diff --git a/soc/arm/microchip_mec/common/soc_espi_v2.h b/soc/arm/microchip_mec/common/soc_espi_v2.h
 new file mode 100644
-index 0000000000..64486b78ca
+index 000000000..64486b78c
 --- /dev/null
 +++ b/soc/arm/microchip_mec/common/soc_espi_v2.h
 @@ -0,0 +1,22 @@
@@ -5606,7 +5606,7 @@ index 0000000000..64486b78ca
 +
 +#endif /* _SOC_ESPI_V2_H_ */
 diff --git a/soc/arm/microchip_mec/mec172x/Kconfig.defconfig.mec172xnsz b/soc/arm/microchip_mec/mec172x/Kconfig.defconfig.mec172xnsz
-index 29b21eff03..9088302206 100644
+index 29b21eff0..908830220 100644
 --- a/soc/arm/microchip_mec/mec172x/Kconfig.defconfig.mec172xnsz
 +++ b/soc/arm/microchip_mec/mec172x/Kconfig.defconfig.mec172xnsz
 @@ -31,4 +31,8 @@ config I2C_XEC_V2
@@ -5619,7 +5619,7 @@ index 29b21eff03..9088302206 100644
 +
  endif # SOC_MEC172X_NSZ
 diff --git a/soc/arm/microchip_mec/mec172x/reg/mec172x_ecia.h b/soc/arm/microchip_mec/mec172x/reg/mec172x_ecia.h
-index 00614c4080..495e425b9e 100644
+index 00614c408..495e425b9 100644
 --- a/soc/arm/microchip_mec/mec172x/reg/mec172x_ecia.h
 +++ b/soc/arm/microchip_mec/mec172x/reg/mec172x_ecia.h
 @@ -1078,6 +1078,18 @@ enum MCHP_GIRQ_INDEX {
@@ -5642,10 +5642,10 @@ index 00614c4080..495e425b9e 100644
  #define MCHP_GPIO_0240_GIRQ_POS		0
  #define MCHP_GPIO_0241_GIRQ_POS		1
 diff --git a/soc/arm/microchip_mec/mec172x/soc.h b/soc/arm/microchip_mec/mec172x/soc.h
-index 0523753c59..a9bbbee1a3 100644
+index 523623f70..91896434f 100644
 --- a/soc/arm/microchip_mec/mec172x/soc.h
 +++ b/soc/arm/microchip_mec/mec172x/soc.h
-@@ -62,6 +62,7 @@
+@@ -280,6 +280,7 @@ typedef enum {
  #include "../common/soc_pins.h"
  #include "../common/soc_espi_channels.h"
  #include "../common/soc_espi_saf.h"
@@ -5654,13 +5654,13 @@ index 0523753c59..a9bbbee1a3 100644
  #endif
  
 -- 
-2.17.1
+2.25.1
 
 
-From 705a2824ba727df5815eff7ccfe4bcd86011a296 Mon Sep 17 00:00:00 2001
+From aada834e635f189175f548cffc8d20aa5795229a Mon Sep 17 00:00:00 2001
 From: Jay Vasanth <jay.vasanth@microchip.com>
 Date: Mon, 1 Nov 2021 14:58:49 -0400
-Subject: [PATCH 021/112] [BACPORTED] Microchip: MEC172x: eSPI driver
+Subject: [PATCH 021/111] Microchip: MEC172x: eSPI driver
 
 Updates to MEC172x eSPI driver to support ACPI shared
 memory region and EC Host Command Subsystem through
@@ -5677,7 +5677,7 @@ Signed-off-by: Jay Vasanth <jay.vasanth@microchip.com>
  create mode 100644 soc/arm/microchip_mec/mec172x/reg/mec172x_emi.h
 
 diff --git a/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts b/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts
-index c81159ad45..468bfbe18a 100644
+index c81159ad4..468bfbe18 100644
 --- a/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts
 +++ b/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts
 @@ -97,6 +97,10 @@
@@ -5692,7 +5692,7 @@ index c81159ad45..468bfbe18a 100644
  	status = "okay";
  };
 diff --git a/drivers/espi/Kconfig.xec_v2 b/drivers/espi/Kconfig.xec_v2
-index 25a3c88a2c..351f90c852 100644
+index 25a3c88a2..351f90c85 100644
 --- a/drivers/espi/Kconfig.xec_v2
 +++ b/drivers/espi/Kconfig.xec_v2
 @@ -10,6 +10,22 @@ config ESPI_XEC_V2
@@ -5719,7 +5719,7 @@ index 25a3c88a2c..351f90c852 100644
  
  config ESPI_OOB_CHANNEL
 diff --git a/drivers/espi/espi_mchp_xec_host_v2.c b/drivers/espi/espi_mchp_xec_host_v2.c
-index a00e7f86d3..1ab30f1753 100644
+index a00e7f86d..1ab30f175 100644
 --- a/drivers/espi/espi_mchp_xec_host_v2.c
 +++ b/drivers/espi/espi_mchp_xec_host_v2.c
 @@ -448,7 +448,8 @@ static int init_acpi_ec0(const struct device *dev)
@@ -5900,7 +5900,7 @@ index a00e7f86d3..1ab30f1753 100644
  #endif
 diff --git a/soc/arm/microchip_mec/mec172x/reg/mec172x_emi.h b/soc/arm/microchip_mec/mec172x/reg/mec172x_emi.h
 new file mode 100644
-index 0000000000..5f4d3748c8
+index 000000000..5f4d3748c
 --- /dev/null
 +++ b/soc/arm/microchip_mec/mec172x/reg/mec172x_emi.h
 @@ -0,0 +1,50 @@
@@ -5955,10 +5955,10 @@ index 0000000000..5f4d3748c8
 +
 +#endif /* #ifndef _MEC172X_EMI_H */
 diff --git a/soc/arm/microchip_mec/mec172x/soc.h b/soc/arm/microchip_mec/mec172x/soc.h
-index a9bbbee1a3..b8ea715a9d 100644
+index 91896434f..c9451b77d 100644
 --- a/soc/arm/microchip_mec/mec172x/soc.h
 +++ b/soc/arm/microchip_mec/mec172x/soc.h
-@@ -39,6 +39,7 @@
+@@ -257,6 +257,7 @@ typedef enum {
  #include "reg/mec172x_pcr.h"
  #include "reg/mec172x_qspi.h"
  #include "reg/mec172x_vbat.h"
@@ -5967,14 +5967,14 @@ index a9bbbee1a3..b8ea715a9d 100644
  /* common peripheral register defines */
  #include "../common/reg/mec_acpi_ec.h"
 -- 
-2.17.1
+2.25.1
 
 
-From 29394c07718814078ced47c056be80b5320e4a93 Mon Sep 17 00:00:00 2001
+From f7385f0760cd11bb8bf1451870f316e27014b258 Mon Sep 17 00:00:00 2001
 From: Jose Alberto Meza <jose.a.meza.arellano@intel.com>
 Date: Mon, 7 Feb 2022 11:45:46 -0800
-Subject: [PATCH 022/112] [BACPORTED] drivers: espi: xec: mec172x: Fix
- compilation when OOB RX async is enabled
+Subject: [PATCH 022/111] drivers: espi: xec: mec172x: Fix compilation when OOB
+ RX async is enabled
 
 Correct MEC172x OOB register access causing compilation error.
 This occurs whenever CONFIG_ESPI_OOB_CHANNEL_RX_ASYNC is
@@ -5986,7 +5986,7 @@ Signed-off-by: Jose Alberto Meza <jose.a.meza.arellano@intel.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/espi/espi_mchp_xec_v2.c b/drivers/espi/espi_mchp_xec_v2.c
-index 016c39ed1a..1faa343356 100644
+index 016c39ed1..1faa34335 100644
 --- a/drivers/espi/espi_mchp_xec_v2.c
 +++ b/drivers/espi/espi_mchp_xec_v2.c
 @@ -910,7 +910,7 @@ static void espi_oob_down_isr(const struct device *dev)
@@ -5999,14 +5999,14 @@ index 016c39ed1a..1faa343356 100644
  		espi_send_callbacks(&data->callbacks, dev, evt);
  #endif
 -- 
-2.17.1
+2.25.1
 
 
-From b3a3057a9bb249797a225668a87a4edddf334dff Mon Sep 17 00:00:00 2001
+From 9a0ff762fa25a17c8f71beedd2e7824735f67d92 Mon Sep 17 00:00:00 2001
 From: Jun Lin <CHLin56@nuvoton.com>
 Date: Wed, 13 Oct 2021 14:17:02 +0800
-Subject: [PATCH 023/112] [BACPORTED] drivers: spi: npcx: add SPI support to
- access the SPI flash
+Subject: [PATCH 023/111] drivers: spi: npcx: add SPI support to access the SPI
+ flash
 
 The FIU/UMA module in the NPCX chip provides an dedicated SPI interface
 to access the SPI flash. This commit adds the driver support for it.
@@ -6037,7 +6037,7 @@ Change-Id: I32bbf09f6e014b728ff8e4692e48151ae759e188
  create mode 100644 dts/bindings/spi/nuvoton,npcx-spi-fiu.yaml
 
 diff --git a/drivers/spi/CMakeLists.txt b/drivers/spi/CMakeLists.txt
-index 169765cb02..1993589a83 100644
+index 169765cb0..1993589a8 100644
 --- a/drivers/spi/CMakeLists.txt
 +++ b/drivers/spi/CMakeLists.txt
 @@ -25,5 +25,6 @@ zephyr_library_sources_ifdef(CONFIG_SPI_XLNX_AXI_QUADSPI spi_xlnx_axi_quadspi.c)
@@ -6048,7 +6048,7 @@ index 169765cb02..1993589a83 100644
  
  zephyr_library_sources_ifdef(CONFIG_USERSPACE		spi_handlers.c)
 diff --git a/drivers/spi/Kconfig b/drivers/spi/Kconfig
-index 1b890fd4f3..bb156de947 100644
+index 1b890fd4f..bb156de94 100644
 --- a/drivers/spi/Kconfig
 +++ b/drivers/spi/Kconfig
 @@ -83,4 +83,6 @@ source "drivers/spi/Kconfig.test"
@@ -6060,7 +6060,7 @@ index 1b890fd4f3..bb156de947 100644
  endif # SPI
 diff --git a/drivers/spi/Kconfig.npcx_fiu b/drivers/spi/Kconfig.npcx_fiu
 new file mode 100644
-index 0000000000..58486998ec
+index 000000000..58486998e
 --- /dev/null
 +++ b/drivers/spi/Kconfig.npcx_fiu
 @@ -0,0 +1,11 @@
@@ -6077,7 +6077,7 @@ index 0000000000..58486998ec
 +	  for the dedicated SPI controller (FIU) to access the NOR flash.
 diff --git a/drivers/spi/spi_npcx_fiu.c b/drivers/spi/spi_npcx_fiu.c
 new file mode 100644
-index 0000000000..4bb6b934c7
+index 000000000..4bb6b934c
 --- /dev/null
 +++ b/drivers/spi/spi_npcx_fiu.c
 @@ -0,0 +1,183 @@
@@ -6265,7 +6265,7 @@ index 0000000000..4bb6b934c7
 +		      &npcx_spi_fiu_config, POST_KERNEL,
 +		      CONFIG_SPI_INIT_PRIORITY, &spi_npcx_fiu_api);
 diff --git a/dts/arm/nuvoton/npcx.dtsi b/dts/arm/nuvoton/npcx.dtsi
-index 61c2db710d..cd1460ec44 100644
+index 61c2db710..cd1460ec4 100644
 --- a/dts/arm/nuvoton/npcx.dtsi
 +++ b/dts/arm/nuvoton/npcx.dtsi
 @@ -559,6 +559,16 @@
@@ -6286,7 +6286,7 @@ index 61c2db710d..cd1460ec44 100644
  
  	soc-if {
 diff --git a/dts/arm/nuvoton/npcx7m6fb.dtsi b/dts/arm/nuvoton/npcx7m6fb.dtsi
-index 1259798975..13758d34e9 100644
+index 125979897..13758d34e 100644
 --- a/dts/arm/nuvoton/npcx7m6fb.dtsi
 +++ b/dts/arm/nuvoton/npcx7m6fb.dtsi
 @@ -25,3 +25,16 @@
@@ -6307,7 +6307,7 @@ index 1259798975..13758d34e9 100644
 +	};
 +};
 diff --git a/dts/arm/nuvoton/npcx7m6fc.dtsi b/dts/arm/nuvoton/npcx7m6fc.dtsi
-index 10e87ad6e8..7f624b07b1 100644
+index 10e87ad6e..7f624b07b 100644
 --- a/dts/arm/nuvoton/npcx7m6fc.dtsi
 +++ b/dts/arm/nuvoton/npcx7m6fc.dtsi
 @@ -25,3 +25,16 @@
@@ -6328,7 +6328,7 @@ index 10e87ad6e8..7f624b07b1 100644
 +	};
 +};
 diff --git a/dts/arm/nuvoton/npcx7m7fc.dtsi b/dts/arm/nuvoton/npcx7m7fc.dtsi
-index e7206e1c80..e6b4209782 100644
+index e7206e1c8..e6b420978 100644
 --- a/dts/arm/nuvoton/npcx7m7fc.dtsi
 +++ b/dts/arm/nuvoton/npcx7m7fc.dtsi
 @@ -25,3 +25,16 @@
@@ -6349,7 +6349,7 @@ index e7206e1c80..e6b4209782 100644
 +	};
 +};
 diff --git a/dts/arm/nuvoton/npcx9m3f.dtsi b/dts/arm/nuvoton/npcx9m3f.dtsi
-index 72a3d6fbfd..6215c6b432 100644
+index 72a3d6fbf..6215c6b43 100644
 --- a/dts/arm/nuvoton/npcx9m3f.dtsi
 +++ b/dts/arm/nuvoton/npcx9m3f.dtsi
 @@ -25,3 +25,16 @@
@@ -6370,7 +6370,7 @@ index 72a3d6fbfd..6215c6b432 100644
 +	};
 +};
 diff --git a/dts/arm/nuvoton/npcx9m6f.dtsi b/dts/arm/nuvoton/npcx9m6f.dtsi
-index f4998884d3..1b86f878ef 100644
+index f4998884d..1b86f878e 100644
 --- a/dts/arm/nuvoton/npcx9m6f.dtsi
 +++ b/dts/arm/nuvoton/npcx9m6f.dtsi
 @@ -25,3 +25,16 @@
@@ -6392,7 +6392,7 @@ index f4998884d3..1b86f878ef 100644
 +};
 diff --git a/dts/bindings/spi/nuvoton,npcx-spi-fiu.yaml b/dts/bindings/spi/nuvoton,npcx-spi-fiu.yaml
 new file mode 100644
-index 0000000000..c74844e8d2
+index 000000000..c74844e8d
 --- /dev/null
 +++ b/dts/bindings/spi/nuvoton,npcx-spi-fiu.yaml
 @@ -0,0 +1,16 @@
@@ -6413,7 +6413,7 @@ index 0000000000..c74844e8d2
 +    label:
 +        required: true
 diff --git a/soc/arm/nuvoton_npcx/common/reg/reg_def.h b/soc/arm/nuvoton_npcx/common/reg/reg_def.h
-index dc87632075..65ffa677b5 100644
+index dc8763207..65ffa677b 100644
 --- a/soc/arm/nuvoton_npcx/common/reg/reg_def.h
 +++ b/soc/arm/nuvoton_npcx/common/reg/reg_def.h
 @@ -1410,4 +1410,97 @@ struct ps2_reg {
@@ -6515,7 +6515,7 @@ index dc87632075..65ffa677b5 100644
 +					UMA_FLD_SHD_SL)
  #endif /* _NUVOTON_NPCX_REG_DEF_H */
 diff --git a/soc/arm/nuvoton_npcx/common/registers.c b/soc/arm/nuvoton_npcx/common/registers.c
-index 7cd4cc6b71..337190769f 100644
+index 7cd4cc6b7..337190769 100644
 --- a/soc/arm/nuvoton_npcx/common/registers.c
 +++ b/soc/arm/nuvoton_npcx/common/registers.c
 @@ -161,3 +161,12 @@ NPCX_REG_OFFSET_CHECK(ps2_reg, PSCON, 0x004);
@@ -6532,7 +6532,7 @@ index 7cd4cc6b71..337190769f 100644
 +NPCX_REG_OFFSET_CHECK(fiu_reg, FIU_RD_CMD, 0x030);
 +NPCX_REG_OFFSET_CHECK(fiu_reg, FIU_EXT_CFG, 0x033);
 diff --git a/soc/arm/nuvoton_npcx/npcx7/Kconfig.defconfig.series b/soc/arm/nuvoton_npcx/npcx7/Kconfig.defconfig.series
-index 928280fe81..e39fa3204a 100644
+index 928280fe8..e39fa3204 100644
 --- a/soc/arm/nuvoton_npcx/npcx7/Kconfig.defconfig.series
 +++ b/soc/arm/nuvoton_npcx/npcx7/Kconfig.defconfig.series
 @@ -106,6 +106,12 @@ config PM_DEVICE
@@ -6549,7 +6549,7 @@ index 928280fe81..e39fa3204a 100644
  
  endif # SOC_SERIES_NPCX7
 diff --git a/soc/arm/nuvoton_npcx/npcx9/Kconfig.defconfig.series b/soc/arm/nuvoton_npcx/npcx9/Kconfig.defconfig.series
-index 959979d2f5..ed16beef09 100644
+index 959979d2f..ed16beef0 100644
 --- a/soc/arm/nuvoton_npcx/npcx9/Kconfig.defconfig.series
 +++ b/soc/arm/nuvoton_npcx/npcx9/Kconfig.defconfig.series
 @@ -116,6 +116,12 @@ config PM_DEVICE
@@ -6566,14 +6566,14 @@ index 959979d2f5..ed16beef09 100644
  
  endif # SOC_SERIES_NPCX9
 -- 
-2.17.1
+2.25.1
 
 
-From 38c8b9af650a8a8fa749fcb0705529a5dcadac3a Mon Sep 17 00:00:00 2001
+From 71803cc28f34b1a3b0053e3796c1dfee5db52cd4 Mon Sep 17 00:00:00 2001
 From: Jun Lin <CHLin56@nuvoton.com>
 Date: Thu, 14 Oct 2021 18:49:44 +0800
-Subject: [PATCH 024/112] [BACPORTED] samples: drivers: spi_flash: add support
- for the NPCX EVB
+Subject: [PATCH 024/111] samples: drivers: spi_flash: add support for the NPCX
+ EVB
 
 This commit adds the support to run the SPI NOR sample code on the
 npcx7m6fb_evb and npcx9m6f_evb boards.
@@ -6590,7 +6590,7 @@ Change-Id: I780c5dfcf53f3ac537da946673fc03f5ee24e90c
 
 diff --git a/samples/drivers/spi_flash/boards/npcx7m6fb_evb.conf b/samples/drivers/spi_flash/boards/npcx7m6fb_evb.conf
 new file mode 100644
-index 0000000000..1cb43af898
+index 000000000..1cb43af89
 --- /dev/null
 +++ b/samples/drivers/spi_flash/boards/npcx7m6fb_evb.conf
 @@ -0,0 +1,7 @@
@@ -6603,7 +6603,7 @@ index 0000000000..1cb43af898
 +CONFIG_SPI_NOR=y
 diff --git a/samples/drivers/spi_flash/boards/npcx9m6f_evb.conf b/samples/drivers/spi_flash/boards/npcx9m6f_evb.conf
 new file mode 100644
-index 0000000000..1cb43af898
+index 000000000..1cb43af89
 --- /dev/null
 +++ b/samples/drivers/spi_flash/boards/npcx9m6f_evb.conf
 @@ -0,0 +1,7 @@
@@ -6615,7 +6615,7 @@ index 0000000000..1cb43af898
 +
 +CONFIG_SPI_NOR=y
 diff --git a/samples/drivers/spi_flash/src/main.c b/samples/drivers/spi_flash/src/main.c
-index 46edd9fa05..706c4358c8 100644
+index 46edd9fa0..706c4358c 100644
 --- a/samples/drivers/spi_flash/src/main.c
 +++ b/samples/drivers/spi_flash/src/main.c
 @@ -33,6 +33,9 @@
@@ -6629,13 +6629,13 @@ index 46edd9fa05..706c4358c8 100644
  #define FLASH_TEST_REGION_OFFSET 0xff000
  #endif
 -- 
-2.17.1
+2.25.1
 
 
-From 1a2dd3eac6766ad17d597ac2e7bb1dba7c6c311a Mon Sep 17 00:00:00 2001
+From c251c161cf3be3c7c735bca180566c7290e7ee86 Mon Sep 17 00:00:00 2001
 From: Marc Reilly <marc@cpdesign.com.au>
 Date: Thu, 2 Dec 2021 16:03:46 +1100
-Subject: [PATCH 025/112] [BACPORTED] drivers: spi: add spi-bitbang driver
+Subject: [PATCH 025/111] drivers: spi: add spi-bitbang driver
 
 This adds an spi master mode driver via bitbanged gpio. Only syncronous
 transfers are implemented. Clock signal timing is accomplished via busy
@@ -6675,7 +6675,7 @@ Signed-off-by: Marc Reilly <marc@cpdesign.com.au>
  create mode 100644 samples/drivers/spi_bitbang/src/main.c
 
 diff --git a/drivers/spi/CMakeLists.txt b/drivers/spi/CMakeLists.txt
-index 1993589a83..e21ceda878 100644
+index 1993589a8..e21ceda87 100644
 --- a/drivers/spi/CMakeLists.txt
 +++ b/drivers/spi/CMakeLists.txt
 @@ -26,5 +26,6 @@ zephyr_library_sources_ifdef(CONFIG_ESP32_SPIM		spi_esp32_spim.c)
@@ -6686,7 +6686,7 @@ index 1993589a83..e21ceda878 100644
  
  zephyr_library_sources_ifdef(CONFIG_USERSPACE		spi_handlers.c)
 diff --git a/drivers/spi/Kconfig b/drivers/spi/Kconfig
-index bb156de947..a5d7e68b40 100644
+index bb156de94..a5d7e68b4 100644
 --- a/drivers/spi/Kconfig
 +++ b/drivers/spi/Kconfig
 @@ -85,4 +85,6 @@ source "drivers/spi/Kconfig.psoc6"
@@ -6698,7 +6698,7 @@ index bb156de947..a5d7e68b40 100644
  endif # SPI
 diff --git a/drivers/spi/Kconfig.bitbang b/drivers/spi/Kconfig.bitbang
 new file mode 100644
-index 0000000000..ba54160df8
+index 000000000..ba54160df
 --- /dev/null
 +++ b/drivers/spi/Kconfig.bitbang
 @@ -0,0 +1,7 @@
@@ -6711,7 +6711,7 @@ index 0000000000..ba54160df8
 +	  Enable the Bitbang SPI controller
 diff --git a/drivers/spi/spi_bitbang.c b/drivers/spi/spi_bitbang.c
 new file mode 100644
-index 0000000000..5ef775fd46
+index 000000000..5ef775fd4
 --- /dev/null
 +++ b/drivers/spi/spi_bitbang.c
 @@ -0,0 +1,301 @@
@@ -7018,7 +7018,7 @@ index 0000000000..5ef775fd46
 +DT_INST_FOREACH_STATUS_OKAY(SPI_BITBANG_INIT)
 diff --git a/dts/bindings/spi/zephyr,spi-bitbang.yaml b/dts/bindings/spi/zephyr,spi-bitbang.yaml
 new file mode 100644
-index 0000000000..61bf3501c5
+index 000000000..61bf3501c
 --- /dev/null
 +++ b/dts/bindings/spi/zephyr,spi-bitbang.yaml
 @@ -0,0 +1,29 @@
@@ -7053,7 +7053,7 @@ index 0000000000..61bf3501c5
 +        If this is not provided the driver will read 0s
 diff --git a/samples/drivers/spi_bitbang/CMakeLists.txt b/samples/drivers/spi_bitbang/CMakeLists.txt
 new file mode 100644
-index 0000000000..bfd9cc2f19
+index 000000000..bfd9cc2f1
 --- /dev/null
 +++ b/samples/drivers/spi_bitbang/CMakeLists.txt
 @@ -0,0 +1,8 @@
@@ -7067,7 +7067,7 @@ index 0000000000..bfd9cc2f19
 +target_sources(app PRIVATE ${app_sources})
 diff --git a/samples/drivers/spi_bitbang/README.rst b/samples/drivers/spi_bitbang/README.rst
 new file mode 100644
-index 0000000000..6b629c9911
+index 000000000..6b629c991
 --- /dev/null
 +++ b/samples/drivers/spi_bitbang/README.rst
 @@ -0,0 +1,54 @@
@@ -7127,7 +7127,7 @@ index 0000000000..6b629c9911
 +   rx (ii) : 0003 0004 0105
 diff --git a/samples/drivers/spi_bitbang/boards/nrf52840dk_nrf52840.overlay b/samples/drivers/spi_bitbang/boards/nrf52840dk_nrf52840.overlay
 new file mode 100644
-index 0000000000..66ea34ea00
+index 000000000..66ea34ea0
 --- /dev/null
 +++ b/samples/drivers/spi_bitbang/boards/nrf52840dk_nrf52840.overlay
 @@ -0,0 +1,19 @@
@@ -7152,7 +7152,7 @@ index 0000000000..66ea34ea00
 +};
 diff --git a/samples/drivers/spi_bitbang/prj.conf b/samples/drivers/spi_bitbang/prj.conf
 new file mode 100644
-index 0000000000..83dd5b2b24
+index 000000000..83dd5b2b2
 --- /dev/null
 +++ b/samples/drivers/spi_bitbang/prj.conf
 @@ -0,0 +1,5 @@
@@ -7163,7 +7163,7 @@ index 0000000000..83dd5b2b24
 +CONFIG_LOG=y
 diff --git a/samples/drivers/spi_bitbang/sample.yaml b/samples/drivers/spi_bitbang/sample.yaml
 new file mode 100644
-index 0000000000..dc64e76bd1
+index 000000000..dc64e76bd
 --- /dev/null
 +++ b/samples/drivers/spi_bitbang/sample.yaml
 @@ -0,0 +1,7 @@
@@ -7176,7 +7176,7 @@ index 0000000000..dc64e76bd1
 +    depends_on: gpio
 diff --git a/samples/drivers/spi_bitbang/src/main.c b/samples/drivers/spi_bitbang/src/main.c
 new file mode 100644
-index 0000000000..e0571432ae
+index 000000000..e0571432a
 --- /dev/null
 +++ b/samples/drivers/spi_bitbang/src/main.c
 @@ -0,0 +1,156 @@
@@ -7337,14 +7337,13 @@ index 0000000000..e0571432ae
 +	}
 +}
 -- 
-2.17.1
+2.25.1
 
 
-From 06d613c95f824ac6c8e83f933fcf5da99ab1b6f4 Mon Sep 17 00:00:00 2001
+From 284cc37df723eb9050512ac4982bb94e031a3000 Mon Sep 17 00:00:00 2001
 From: Jay Vasanth <jay.vasanth@microchip.com>
 Date: Mon, 25 Oct 2021 19:06:41 -0400
-Subject: [PATCH 026/112] [BACPORTED] drivers: spi: Add MEC172x QMSPI-LDMA
- driver
+Subject: [PATCH 026/111] drivers: spi: Add MEC172x QMSPI-LDMA driver
 
 Add driver for MEC172x QMSPI with local DMA(LDMA). The driver
 support SPI asynchronous operation.
@@ -7369,7 +7368,7 @@ Signed-off-by: Jay Vasanth <jay.vasanth@microchip.com>
  create mode 100644 dts/bindings/spi/microchip,xec-qmspi-ldma.yaml
 
 diff --git a/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts b/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts
-index 468bfbe18a..620fa08712 100644
+index 468bfbe18..620fa0871 100644
 --- a/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts
 +++ b/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts
 @@ -46,6 +46,7 @@
@@ -7392,7 +7391,7 @@ index 468bfbe18a..620fa08712 100644
 +	chip-select = <0>;
 +};
 diff --git a/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906_defconfig b/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906_defconfig
-index 80eb72b962..1d662ffe26 100644
+index 80eb72b96..1d662ffe2 100644
 --- a/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906_defconfig
 +++ b/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906_defconfig
 @@ -18,3 +18,5 @@ CONFIG_UART_CONSOLE=y
@@ -7402,7 +7401,7 @@ index 80eb72b962..1d662ffe26 100644
 +CONFIG_SPI=y
 +CONFIG_SPI_ASYNC=y
 diff --git a/drivers/spi/CMakeLists.txt b/drivers/spi/CMakeLists.txt
-index e21ceda878..8a36d8be92 100644
+index e21ceda87..8a36d8be9 100644
 --- a/drivers/spi/CMakeLists.txt
 +++ b/drivers/spi/CMakeLists.txt
 @@ -27,5 +27,6 @@ zephyr_library_sources_ifdef(CONFIG_SPI_TEST		spi_test.c)
@@ -7413,7 +7412,7 @@ index e21ceda878..8a36d8be92 100644
  
  zephyr_library_sources_ifdef(CONFIG_USERSPACE		spi_handlers.c)
 diff --git a/drivers/spi/Kconfig b/drivers/spi/Kconfig
-index a5d7e68b40..eb9b9684a6 100644
+index a5d7e68b4..eb9b9684a 100644
 --- a/drivers/spi/Kconfig
 +++ b/drivers/spi/Kconfig
 @@ -87,4 +87,6 @@ source "drivers/spi/Kconfig.npcx_fiu"
@@ -7424,7 +7423,7 @@ index a5d7e68b40..eb9b9684a6 100644
 +
  endif # SPI
 diff --git a/drivers/spi/Kconfig.xec_qmspi b/drivers/spi/Kconfig.xec_qmspi
-index f7fd70e6c8..82ac913bb1 100644
+index f7fd70e6c..82ac913bb 100644
 --- a/drivers/spi/Kconfig.xec_qmspi
 +++ b/drivers/spi/Kconfig.xec_qmspi
 @@ -6,7 +6,7 @@
@@ -7438,7 +7437,7 @@ index f7fd70e6c8..82ac913bb1 100644
  	  Enable support for the Microchip XEC QMSPI driver.
 diff --git a/drivers/spi/Kconfig.xec_qmspi_ldma b/drivers/spi/Kconfig.xec_qmspi_ldma
 new file mode 100644
-index 0000000000..f0f3e006a3
+index 000000000..f0f3e006a
 --- /dev/null
 +++ b/drivers/spi/Kconfig.xec_qmspi_ldma
 @@ -0,0 +1,11 @@
@@ -7455,7 +7454,7 @@ index 0000000000..f0f3e006a3
 +	  Enable support for the Microchip XEC QMSPI with local DMA driver.
 diff --git a/drivers/spi/spi_xec_qmspi_ldma.c b/drivers/spi/spi_xec_qmspi_ldma.c
 new file mode 100644
-index 0000000000..c99942e707
+index 000000000..c99942e70
 --- /dev/null
 +++ b/drivers/spi/spi_xec_qmspi_ldma.c
 @@ -0,0 +1,1343 @@
@@ -8803,7 +8802,7 @@ index 0000000000..c99942e707
 +
 +DT_INST_FOREACH_STATUS_OKAY(QMSPI_XEC_DEVICE)
 diff --git a/dts/arm/microchip/mec172xnsz.dtsi b/dts/arm/microchip/mec172xnsz.dtsi
-index 7a96a43dff..94647327ac 100644
+index 7a96a43df..94647327a 100644
 --- a/dts/arm/microchip/mec172xnsz.dtsi
 +++ b/dts/arm/microchip/mec172xnsz.dtsi
 @@ -754,23 +754,17 @@
@@ -8835,7 +8834,7 @@ index 7a96a43dff..94647327ac 100644
  		spi1: spi@40009400 {
 diff --git a/dts/bindings/spi/microchip,xec-qmspi-ldma.yaml b/dts/bindings/spi/microchip,xec-qmspi-ldma.yaml
 new file mode 100644
-index 0000000000..baa2b24c9a
+index 000000000..baa2b24c9
 --- /dev/null
 +++ b/dts/bindings/spi/microchip,xec-qmspi-ldma.yaml
 @@ -0,0 +1,106 @@
@@ -8946,7 +8945,7 @@ index 0000000000..baa2b24c9a
 +        An optional signed 8-bit value for adjusting the QMSPI clock signal
 +        timing tap.
 diff --git a/soc/arm/microchip_mec/mec172x/Kconfig.defconfig.mec172xnsz b/soc/arm/microchip_mec/mec172x/Kconfig.defconfig.mec172xnsz
-index 9088302206..dfc41faa4a 100644
+index 908830220..dfc41faa4 100644
 --- a/soc/arm/microchip_mec/mec172x/Kconfig.defconfig.mec172xnsz
 +++ b/soc/arm/microchip_mec/mec172x/Kconfig.defconfig.mec172xnsz
 @@ -35,4 +35,8 @@ config ESPI_XEC_V2
@@ -8959,7 +8958,7 @@ index 9088302206..dfc41faa4a 100644
 +
  endif # SOC_MEC172X_NSZ
 diff --git a/soc/arm/microchip_mec/mec172x/reg/mec172x_gpio.h b/soc/arm/microchip_mec/mec172x/reg/mec172x_gpio.h
-index 7033daa6ec..5c45004356 100644
+index 7033daa6e..5c4500435 100644
 --- a/soc/arm/microchip_mec/mec172x/reg/mec172x_gpio.h
 +++ b/soc/arm/microchip_mec/mec172x/reg/mec172x_gpio.h
 @@ -21,8 +21,8 @@
@@ -8974,7 +8973,7 @@ index 7033daa6ec..5c45004356 100644
  #define MCHP_GPIO_PORT_E_BITMAP 0x00DE00FFu /* GPIO_0200 - 0236  GIRQ12 */
  #define MCHP_GPIO_PORT_F_BITMAP 0x0000397Fu /* GPIO_0240 - 0276  GIRQ26 */
 diff --git a/soc/arm/microchip_mec/mec172x/reg/mec172x_qspi.h b/soc/arm/microchip_mec/mec172x/reg/mec172x_qspi.h
-index e938272261..cb2be6eed4 100644
+index e93827226..cb2be6eed 100644
 --- a/soc/arm/microchip_mec/mec172x/reg/mec172x_qspi.h
 +++ b/soc/arm/microchip_mec/mec172x/reg/mec172x_qspi.h
 @@ -252,12 +252,14 @@
@@ -9003,262 +9002,13 @@ index e938272261..cb2be6eed4 100644
  #define MCHP_QMSPI_IEN_TXB_EMPTY	BIT(9)
  #define MCHP_QMSPI_IEN_TXB_REQ		BIT(10)
 -- 
-2.17.1
+2.25.1
 
 
-From f24bc1fca464f049793b1ad838415d73805834d0 Mon Sep 17 00:00:00 2001
-From: Jay Vasanth <jay.vasanth@microchip.com>
-Date: Thu, 16 Dec 2021 16:52:07 -0500
-Subject: [PATCH 027/112] [BACPORTED] soc arm: MEC172x soc.h - Include custom
- IRQn_Type
-
-Fix for issue #41012 to allow compiler to treat
-IRQn_Type to be more than 8-bit. This will ensure NVIC numbers
-more than 127 (required for MEC172x device) will work
-correctly with irq_enable() API
-
-Signed-off-by: Jay Vasanth <jay.vasanth@microchip.com>
----
- soc/arm/microchip_mec/mec172x/soc.h | 218 ++++++++++++++++++++++++++++
- 1 file changed, 218 insertions(+)
-
-diff --git a/soc/arm/microchip_mec/mec172x/soc.h b/soc/arm/microchip_mec/mec172x/soc.h
-index b8ea715a9d..c9451b77d6 100644
---- a/soc/arm/microchip_mec/mec172x/soc.h
-+++ b/soc/arm/microchip_mec/mec172x/soc.h
-@@ -24,6 +24,224 @@
- #define __FPU_PRESENT  CONFIG_CPU_HAS_FPU
- #define __MPU_PRESENT  CONFIG_CPU_HAS_ARM_MPU
- 
-+#define __CM4_REV 0x0201                /*!< Core Revision r2p1 */
-+
-+#define __VTOR_PRESENT 1                /*!< Set to 1 if VTOR is present */
-+#define __NVIC_PRIO_BITS 3              /*!< Number of Bits used for Priority Levels */
-+#define __Vendor_SysTickConfig 0        /*!< 0 use default SysTick HW */
-+#define __FPU_DP 0                      /*!< Set to 1 if FPU is double precision */
-+#define __ICACHE_PRESENT 0              /*!< Set to 1 if I-Cache is present */
-+#define __DCACHE_PRESENT 0              /*!< Set to 1 if D-Cache is present */
-+#define __DTCM_PRESENT 0                /*!< Set to 1 if DTCM is present */
-+
-+/** @brief ARM Cortex-M4 NVIC Interrupt Numbers
-+ * CM4 NVIC implements 16 internal interrupt sources. CMSIS macros use
-+ * negative numbers [-15, -1]. Lower numerical value indicates higher
-+ * priority.
-+ * -15 = Reset Vector invoked on POR or any CPU reset.
-+ * -14 = NMI
-+ * -13 = Hard Fault. At POR or CPU reset all faults map to Hard Fault.
-+ * -12 = Memory Management Fault. If enabled Hard Faults caused by access
-+ *       violations, no address match, or MPU mismatch.
-+ * -11 = Bus Fault. If enabled pre-fetch, AHB access faults.
-+ * -10 = Usage Fault. If enabled Undefined instructions, illegal state
-+ *       transition (Thumb -> ARM mode), unaligned, etc.
-+ * -9 through -6 are not implemented (reserved).
-+ * -5 System call via SVC instruction.
-+ * -4 Debug Monitor.
-+ * -3 not implemented (reserved).
-+ * -2 PendSV for system service.
-+ * -1 SysTick NVIC system timer.
-+ * Numbers >= 0 are external peripheral interrupts.
-+ */
-+typedef enum {
-+	/* ========== ARM Cortex-M4 Specific Interrupt Numbers ============ */
-+
-+	Reset_IRQn              = -15,  /*!< POR/CPU Reset Vector */
-+	NonMaskableInt_IRQn     = -14,  /*!< NMI */
-+	HardFault_IRQn          = -13,  /*!< Hard Faults */
-+	MemoryManagement_IRQn   = -12,  /*!< Memory Management faults */
-+	BusFault_IRQn           = -11,  /*!< Bus Access faults */
-+	UsageFault_IRQn         = -10,  /*!< Usage/instruction faults */
-+	SVCall_IRQn             = -5,   /*!< SVC */
-+	DebugMonitor_IRQn       = -4,   /*!< Debug Monitor */
-+	PendSV_IRQn             = -2,   /*!< PendSV */
-+	SysTick_IRQn            = -1,   /*!< SysTick */
-+
-+	/* ==============  MEC172x Specific Interrupt Numbers ============ */
-+
-+	GIRQ08_IRQn             = 0,    /*!< GPIO 0140 - 0176 */
-+	GIRQ09_IRQn             = 1,    /*!< GPIO 0100 - 0136 */
-+	GIRQ10_IRQn             = 2,    /*!< GPIO 0040 - 0076 */
-+	GIRQ11_IRQn             = 3,    /*!< GPIO 0000 - 0036 */
-+	GIRQ12_IRQn             = 4,    /*!< GPIO 0200 - 0236 */
-+	GIRQ13_IRQn             = 5,    /*!< SMBus Aggregated */
-+	GIRQ14_IRQn             = 6,    /*!< DMA Aggregated */
-+	GIRQ15_IRQn             = 7,
-+	GIRQ16_IRQn             = 8,
-+	GIRQ17_IRQn             = 9,
-+	GIRQ18_IRQn             = 10,
-+	GIRQ19_IRQn             = 11,
-+	GIRQ20_IRQn             = 12,
-+	GIRQ21_IRQn             = 13,
-+	/* GIRQ22(peripheral clock wake) is not connected to NVIC */
-+	GIRQ23_IRQn             = 14,
-+	GIRQ24_IRQn             = 15,
-+	GIRQ25_IRQn             = 16,
-+	GIRQ26_IRQn             = 17, /*!< GPIO 0240 - 0276 */
-+	/* Reserved 18-19 */
-+	/* GIRQ's 8 - 12, 24 - 26 no direct connections */
-+	I2C_SMB_0_IRQn          = 20,   /*!< GIRQ13 b[0] */
-+	I2C_SMB_1_IRQn          = 21,   /*!< GIRQ13 b[1] */
-+	I2C_SMB_2_IRQn          = 22,   /*!< GIRQ13 b[2] */
-+	I2C_SMB_3_IRQn          = 23,   /*!< GIRQ13 b[3] */
-+	DMA0_IRQn               = 24,   /*!< GIRQ14 b[0] */
-+	DMA1_IRQn               = 25,   /*!< GIRQ14 b[1] */
-+	DMA2_IRQn               = 26,   /*!< GIRQ14 b[2] */
-+	DMA3_IRQn               = 27,   /*!< GIRQ14 b[3] */
-+	DMA4_IRQn               = 28,   /*!< GIRQ14 b[4] */
-+	DMA5_IRQn               = 29,   /*!< GIRQ14 b[5] */
-+	DMA6_IRQn               = 30,   /*!< GIRQ14 b[6] */
-+	DMA7_IRQn               = 31,   /*!< GIRQ14 b[7] */
-+	DMA8_IRQn               = 32,   /*!< GIRQ14 b[8] */
-+	DMA9_IRQn               = 33,   /*!< GIRQ14 b[9] */
-+	DMA10_IRQn              = 34,   /*!< GIRQ14 b[10] */
-+	DMA11_IRQn              = 35,   /*!< GIRQ14 b[11] */
-+	DMA12_IRQn              = 36,   /*!< GIRQ14 b[12] */
-+	DMA13_IRQn              = 37,   /*!< GIRQ14 b[13] */
-+	DMA14_IRQn              = 38,   /*!< GIRQ14 b[14] */
-+	DMA15_IRQn              = 39,   /*!< GIRQ14 b[15] */
-+	UART0_IRQn              = 40,   /*!< GIRQ15 b[0] */
-+	UART1_IRQn              = 41,   /*!< GIRQ15 b[1] */
-+	EMI0_IRQn               = 42,   /*!< GIRQ15 b[2] */
-+	EMI1_IRQn               = 43,   /*!< GIRQ15 b[3] */
-+	EMI2_IRQn               = 44,   /*!< GIRQ15 b[4] */
-+	ACPI_EC0_IBF_IRQn       = 45,   /*!< GIRQ15 b[5] */
-+	ACPI_EC0_OBE_IRQn       = 46,   /*!< GIRQ15 b[6] */
-+	ACPI_EC1_IBF_IRQn       = 47,   /*!< GIRQ15 b[7] */
-+	ACPI_EC1_OBE_IRQn       = 48,   /*!< GIRQ15 b[8] */
-+	ACPI_EC2_IBF_IRQn       = 49,   /*!< GIRQ15 b[9] */
-+	ACPI_EC2_OBE_IRQn       = 50,   /*!< GIRQ15 b[10] */
-+	ACPI_EC3_IBF_IRQn       = 51,   /*!< GIRQ15 b[11] */
-+	ACPI_EC3_OBE_IRQn       = 52,   /*!< GIRQ15 b[12] */
-+	ACPI_EC4_IBF_IRQn       = 53,   /*!< GIRQ15 b[13] */
-+	ACPI_EC4_OBE_IRQn       = 54,   /*!< GIRQ15 b[14] */
-+	ACPI_PM1_CTL_IRQn       = 55,   /*!< GIRQ15 b[15] */
-+	ACPI_PM1_EN_IRQn        = 56,   /*!< GIRQ15 b[16] */
-+	ACPI_PM1_STS_IRQn       = 57,   /*!< GIRQ15 b[17] */
-+	KBC_OBE_IRQn            = 58,   /*!< GIRQ15 b[18] */
-+	KBC_IBF_IRQn            = 59,   /*!< GIRQ15 b[19] */
-+	MBOX_IRQn               = 60,   /*!< GIRQ15 b[20] */
-+	/* reserved 61 */
-+	P80BD_0_IRQn            = 62,   /*!< GIRQ15 b[22] */
-+	/* reserved 63-64 */
-+	PKE_IRQn                = 65,   /*!< GIRQ16 b[0] */
-+	/* reserved 66 */
-+	RNG_IRQn                = 67,   /*!< GIRQ16 b[2] */
-+	AESH_IRQn               = 68,   /*!< GIRQ16 b[3] */
-+	/* reserved 69 */
-+	PECI_IRQn               = 70,   /*!< GIRQ17 b[0] */
-+	TACH_0_IRQn             = 71,   /*!< GIRQ17 b[1] */
-+	TACH_1_IRQn             = 72,   /*!< GIRQ17 b[2] */
-+	TACH_2_IRQn             = 73,   /*!< GIRQ17 b[3] */
-+	RPMFAN_0_FAIL_IRQn      = 74,   /*!< GIRQ17 b[20] */
-+	RPMFAN_0_STALL_IRQn     = 75,   /*!< GIRQ17 b[21] */
-+	RPMFAN_1_FAIL_IRQn      = 76,   /*!< GIRQ17 b[22] */
-+	RPMFAN_1_STALL_IRQn     = 77,   /*!< GIRQ17 b[23] */
-+	ADC_SNGL_IRQn           = 78,   /*!< GIRQ17 b[8] */
-+	ADC_RPT_IRQn            = 79,   /*!< GIRQ17 b[9] */
-+	RCID_0_IRQn             = 80,   /*!< GIRQ17 b[10] */
-+	RCID_1_IRQn             = 81,   /*!< GIRQ17 b[11] */
-+	RCID_2_IRQn             = 82,   /*!< GIRQ17 b[12] */
-+	LED_0_IRQn              = 83,   /*!< GIRQ17 b[13] */
-+	LED_1_IRQn              = 84,   /*!< GIRQ17 b[14] */
-+	LED_2_IRQn              = 85,   /*!< GIRQ17 b[15] */
-+	LED_3_IRQn              = 86,   /*!< GIRQ17 b[16] */
-+	PHOT_IRQn               = 87,   /*!< GIRQ17 b[17] */
-+	/* reserved 88-89 */
-+	SPIP_0_IRQn             = 90,   /*!< GIRQ18 b[0] */
-+	QMSPI_0_IRQn            = 91,   /*!< GIRQ18 b[1] */
-+	GPSPI_0_TXBE_IRQn       = 92,   /*!< GIRQ18 b[2] */
-+	GPSPI_0_RXBF_IRQn       = 93,   /*!< GIRQ18 b[3] */
-+	GPSPI_1_TXBE_IRQn       = 94,   /*!< GIRQ18 b[4] */
-+	GPSPI_1_RXBF_IRQn       = 95,   /*!< GIRQ18 b[5] */
-+	BCL_0_ERR_IRQn          = 96,   /*!< GIRQ18 b[7] */
-+	BCL_0_BCLR_IRQn         = 97,   /*!< GIRQ18 b[6] */
-+	/* reserved 98-99 */
-+	PS2_0_ACT_IRQn          = 100,  /*!< GIRQ18 b[10] */
-+	/* reserved 101-102 */
-+	ESPI_PC_IRQn            = 103,  /*!< GIRQ19 b[0] */
-+	ESPI_BM1_IRQn           = 104,  /*!< GIRQ19 b[1] */
-+	ESPI_BM2_IRQn           = 105,  /*!< GIRQ19 b[2] */
-+	ESPI_LTR_IRQn           = 106,  /*!< GIRQ19 b[3] */
-+	ESPI_OOB_UP_IRQn        = 107,  /*!< GIRQ19 b[4] */
-+	ESPI_OOB_DN_IRQn        = 108,  /*!< GIRQ19 b[5] */
-+	ESPI_FLASH_IRQn         = 109,  /*!< GIRQ19 b[6] */
-+	ESPI_RESET_IRQn         = 110,  /*!< GIRQ19 b[7] */
-+	RTMR_IRQn               = 111,  /*!< GIRQ23 b[10] */
-+	HTMR_0_IRQn             = 112,  /*!< GIRQ23 b[16] */
-+	HTMR_1_IRQn             = 113,  /*!< GIRQ23 b[17] */
-+	WK_IRQn                 = 114,  /*!< GIRQ21 b[3] */
-+	WKSUB_IRQn              = 115,  /*!< GIRQ21 b[4] */
-+	WKSEC_IRQn              = 116,  /*!< GIRQ21 b[5] */
-+	WKSUBSEC_IRQn           = 117,  /*!< GIRQ21 b[6] */
-+	WKSYSPWR_IRQn           = 118,  /*!< GIRQ21 b[7] */
-+	RTC_IRQn                = 119,  /*!< GIRQ21 b[8] */
-+	RTC_ALARM_IRQn          = 120,  /*!< GIRQ21 b[9] */
-+	VCI_OVRD_IN_IRQn        = 121,  /*!< GIRQ21 b[10] */
-+	VCI_IN0_IRQn            = 122,  /*!< GIRQ21 b[11] */
-+	VCI_IN1_IRQn            = 123,  /*!< GIRQ21 b[12] */
-+	VCI_IN2_IRQn            = 124,  /*!< GIRQ21 b[13] */
-+	VCI_IN3_IRQn            = 125,  /*!< GIRQ21 b[14] */
-+	VCI_IN4_IRQn            = 126,  /*!< GIRQ21 b[15] */
-+	/* reserved 127-128 */
-+	PS2_0A_WAKE_IRQn        = 129,  /*!< GIRQ21 b[18] */
-+	PS2_0B_WAKE_IRQn        = 130,  /*!< GIRQ21 b[19] */
-+	/* reserved 131-134 */
-+	KEYSCAN_IRQn            = 135,  /*!< GIRQ21 b[25] */
-+	B16TMR_0_IRQn           = 136,  /*!< GIRQ23 b[0] */
-+	B16TMR_1_IRQn           = 137,  /*!< GIRQ23 b[1] */
-+	B16TMR_2_IRQn           = 138,  /*!< GIRQ23 b[2] */
-+	B16TMR_3_IRQn           = 139,  /*!< GIRQ23 b[3] */
-+	B32TMR_0_IRQn           = 140,  /*!< GIRQ23 b[4] */
-+	B32TMR_1_IRQn           = 141,  /*!< GIRQ23 b[5] */
-+	CTMR_0_IRQn             = 142,  /*!< GIRQ23 b[6] */
-+	CTMR_1_IRQn             = 143,  /*!< GIRQ23 b[7] */
-+	CTMR_2_IRQn             = 144,  /*!< GIRQ23 b[8] */
-+	CTMR_3_IRQn             = 145,  /*!< GIRQ23 b[9] */
-+	CCT_IRQn                = 146,  /*!< GIRQ18 b[20] */
-+	CCT_CAP0_IRQn           = 147,  /*!< GIRQ18 b[21] */
-+	CCT_CAP1_IRQn           = 148,  /*!< GIRQ18 b[22] */
-+	CCT_CAP2_IRQn           = 149,  /*!< GIRQ18 b[23] */
-+	CCT_CAP3_IRQn           = 150,  /*!< GIRQ18 b[24] */
-+	CCT_CAP4_IRQn           = 151,  /*!< GIRQ18 b[25] */
-+	CCT_CAP5_IRQn           = 152,  /*!< GIRQ18 b[26] */
-+	CCT_CMP0_IRQn           = 153,  /*!< GIRQ18 b[27] */
-+	CCT_CMP1_IRQn           = 154,  /*!< GIRQ18 b[28] */
-+	EEPROMC_IRQn            = 155,  /*!< GIRQ18 b[13] */
-+	ESPI_VWIRE_IRQn         = 156,  /*!< GIRQ19 b[8] */
-+	/* reserved 157 */
-+	I2C_SMB_4_IRQn          = 158,  /*!< GIRQ13 b[4] */
-+	TACH_3_IRQn             = 159,  /*!< GIRQ17 b[4] */
-+	/* reserved 160-165 */
-+	SAF_DONE_IRQn           = 166,  /*!< GIRQ19 b[9] */
-+	SAF_ERR_IRQn            = 167,  /*!< GIRQ19 b[10] */
-+	/* reserved 168 */
-+	SAF_CACHE_IRQn          = 169,  /*!< GIRQ19 b[11] */
-+	/* reserved 170 */
-+	WDT_0_IRQn              = 171,  /*!< GIRQ21 b[2] */
-+	GLUE_IRQn               = 172,  /*!< GIRQ21 b[26] */
-+	OTP_RDY_IRQn            = 173,  /*!< GIRQ20 b[3] */
-+	CLK32K_MON_IRQn         = 174,  /*!< GIRQ20 b[9] */
-+	ACPI_EC0_IRQn           = 175,  /* ACPI EC OBE and IBF combined into one */
-+	ACPI_EC1_IRQn           = 176,  /* No GIRQ connection. Status in ACPI blocks */
-+	ACPI_EC2_IRQn           = 177,  /* Code uses level bits and NVIC bits */
-+	ACPI_EC3_IRQn           = 178,
-+	ACPI_EC4_IRQn           = 179,
-+	ACPI_PM1_IRQn           = 180,
-+	MAX_IRQn
-+} IRQn_Type;
-+
- #include <sys/util.h>
- 
- /* chip specific register defines */
--- 
-2.17.1
-
-
-From c49d3303f0e15b10579794900a831187cd6869e1 Mon Sep 17 00:00:00 2001
+From 4a6b9ee7c8ec5c1889a7dcde7ee157daad8bb315 Mon Sep 17 00:00:00 2001
 From: Jay Vasanth <jay.vasanth@microchip.com>
 Date: Mon, 22 Nov 2021 14:41:23 -0500
-Subject: [PATCH 028/112] [BACPORTED] Microchip: MEC172x: kscan driver
+Subject: [PATCH 027/111] Microchip: MEC172x: kscan driver
 
 Update keyscan driver to support MEC172x device
 
@@ -9273,7 +9023,7 @@ Signed-off-by: Jay Vasanth <jay.vasanth@microchip.com>
  6 files changed, 248 insertions(+), 94 deletions(-)
 
 diff --git a/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts b/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts
-index 620fa08712..eabaab748b 100644
+index 620fa0871..eabaab748 100644
 --- a/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts
 +++ b/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts
 @@ -147,3 +147,7 @@
@@ -9285,7 +9035,7 @@ index 620fa08712..eabaab748b 100644
 +	status = "okay";
 +};
 diff --git a/boards/arm/mec172xevb_assy6906/pinmux.c b/boards/arm/mec172xevb_assy6906/pinmux.c
-index 871fff3649..36ea01184a 100644
+index 871fff364..36ea01184 100644
 --- a/boards/arm/mec172xevb_assy6906/pinmux.c
 +++ b/boards/arm/mec172xevb_assy6906/pinmux.c
 @@ -74,6 +74,36 @@ const struct pin_info espi_pin_table[] = {
@@ -9334,7 +9084,7 @@ index 871fff3649..36ea01184a 100644
  	return 0;
  }
 diff --git a/drivers/kscan/Kconfig.xec b/drivers/kscan/Kconfig.xec
-index 5214879e81..a39ad6de71 100644
+index 5214879e8..a39ad6de7 100644
 --- a/drivers/kscan/Kconfig.xec
 +++ b/drivers/kscan/Kconfig.xec
 @@ -3,9 +3,12 @@
@@ -9391,7 +9141,7 @@ index 5214879e81..a39ad6de71 100644
  	help
  	  Defines the poll period in msecs between between matrix scans.
 diff --git a/drivers/kscan/kscan_mchp_xec.c b/drivers/kscan/kscan_mchp_xec.c
-index ec172f39bb..17d99d2404 100644
+index ec172f39b..17d99d240 100644
 --- a/drivers/kscan/kscan_mchp_xec.c
 +++ b/drivers/kscan/kscan_mchp_xec.c
 @@ -1,6 +1,6 @@
@@ -9889,7 +9639,7 @@ index ec172f39bb..17d99d2404 100644
 +		      POST_KERNEL, CONFIG_KSCAN_INIT_PRIORITY,
 +		      &kscan_xec_driver_api);
 diff --git a/dts/arm/microchip/mec172xnsz.dtsi b/dts/arm/microchip/mec172xnsz.dtsi
-index 94647327ac..96ddd471c8 100644
+index 94647327a..96ddd471c 100644
 --- a/dts/arm/microchip/mec172xnsz.dtsi
 +++ b/dts/arm/microchip/mec172xnsz.dtsi
 @@ -735,6 +735,7 @@
@@ -9901,7 +9651,7 @@ index 94647327ac..96ddd471c8 100644
  			interrupts = <135 0>;
  			girqs = <21 25>;
 diff --git a/dts/bindings/kscan/microchip,xec-kscan.yaml b/dts/bindings/kscan/microchip,xec-kscan.yaml
-index 318d70a036..70e149c52b 100644
+index 318d70a03..70e149c52 100644
 --- a/dts/bindings/kscan/microchip,xec-kscan.yaml
 +++ b/dts/bindings/kscan/microchip,xec-kscan.yaml
 @@ -1,11 +1,12 @@
@@ -9941,14 +9691,13 @@ index 318d70a036..70e149c52b 100644
 +    - regidx
 +    - bitpos
 -- 
-2.17.1
+2.25.1
 
 
-From 3a156cc8efeaa70889700eb13eec926693efc201 Mon Sep 17 00:00:00 2001
+From b4ff6201a30f2b4343bf51e8e451c2dea9f4df60 Mon Sep 17 00:00:00 2001
 From: Jay Vasanth <jay.vasanth@microchip.com>
 Date: Thu, 3 Feb 2022 14:14:26 -0500
-Subject: [PATCH 029/112] [BACPORTED] drivers: bbram: Add bbram driver for mec
- device
+Subject: [PATCH 028/111] drivers: bbram: Add bbram driver for mec device
 
 Add bbram driver for Microchip mec device
 
@@ -9967,7 +9716,7 @@ Signed-off-by: Jay Vasanth <jay.vasanth@microchip.com>
  create mode 100644 dts/bindings/memory-controllers/microchip,xec-bbram.yaml
 
 diff --git a/drivers/bbram/CMakeLists.txt b/drivers/bbram/CMakeLists.txt
-index 7d9940ef3b..db171e593e 100644
+index 7d9940ef3..db171e593 100644
 --- a/drivers/bbram/CMakeLists.txt
 +++ b/drivers/bbram/CMakeLists.txt
 @@ -6,3 +6,4 @@ zephyr_library()
@@ -9976,7 +9725,7 @@ index 7d9940ef3b..db171e593e 100644
  zephyr_library_sources_ifdef(CONFIG_BBRAM_EMUL bbram_emul.c)
 +zephyr_library_sources_ifdef(CONFIG_BBRAM_XEC bbram_xec.c)
 diff --git a/drivers/bbram/Kconfig b/drivers/bbram/Kconfig
-index 1a947282f3..4280c6d2b0 100644
+index 1a947282f..4280c6d2b 100644
 --- a/drivers/bbram/Kconfig
 +++ b/drivers/bbram/Kconfig
 @@ -24,4 +24,6 @@ source "drivers/bbram/Kconfig.it8xxx2"
@@ -9988,7 +9737,7 @@ index 1a947282f3..4280c6d2b0 100644
  endif # BBRAM
 diff --git a/drivers/bbram/Kconfig.xec b/drivers/bbram/Kconfig.xec
 new file mode 100644
-index 0000000000..d715a8565c
+index 000000000..d715a8565
 --- /dev/null
 +++ b/drivers/bbram/Kconfig.xec
 @@ -0,0 +1,13 @@
@@ -10007,7 +9756,7 @@ index 0000000000..d715a8565c
 +	  processors.
 diff --git a/drivers/bbram/bbram_xec.c b/drivers/bbram/bbram_xec.c
 new file mode 100644
-index 0000000000..6b3c0d7fc1
+index 000000000..6b3c0d7fc
 --- /dev/null
 +++ b/drivers/bbram/bbram_xec.c
 @@ -0,0 +1,99 @@
@@ -10111,7 +9860,7 @@ index 0000000000..6b3c0d7fc1
 +
 +DT_INST_FOREACH_STATUS_OKAY(BBRAM_INIT);
 diff --git a/dts/arm/microchip/mec1501hsz.dtsi b/dts/arm/microchip/mec1501hsz.dtsi
-index 5a10c73142..e930ac5d30 100644
+index 5a10c7314..e930ac5d3 100644
 --- a/dts/arm/microchip/mec1501hsz.dtsi
 +++ b/dts/arm/microchip/mec1501hsz.dtsi
 @@ -85,6 +85,12 @@
@@ -10128,7 +9877,7 @@ index 5a10c73142..e930ac5d30 100644
  			compatible = "microchip,xec-watchdog";
  			reg = <0x40000400 0x400>;
 diff --git a/dts/arm/microchip/mec172xnsz.dtsi b/dts/arm/microchip/mec172xnsz.dtsi
-index 96ddd471c8..0d45a2467c 100644
+index 96ddd471c..0d45a2467 100644
 --- a/dts/arm/microchip/mec172xnsz.dtsi
 +++ b/dts/arm/microchip/mec172xnsz.dtsi
 @@ -507,9 +507,11 @@
@@ -10147,7 +9896,7 @@ index 96ddd471c8..0d45a2467c 100644
  			reg = <0x4000ae00 0x40>;
 diff --git a/dts/bindings/memory-controllers/microchip,xec-bbram.yaml b/dts/bindings/memory-controllers/microchip,xec-bbram.yaml
 new file mode 100644
-index 0000000000..aeca313be1
+index 000000000..aeca313be
 --- /dev/null
 +++ b/dts/bindings/memory-controllers/microchip,xec-bbram.yaml
 @@ -0,0 +1,12 @@
@@ -10164,13 +9913,13 @@ index 0000000000..aeca313be1
 +    reg:
 +        required: true
 -- 
-2.17.1
+2.25.1
 
 
-From 7ea5dcd1dc43735e07bf0416e0340f75aef3c56b Mon Sep 17 00:00:00 2001
+From 443a29ebec424a41eeb74954c4a2fb89685381ec Mon Sep 17 00:00:00 2001
 From: Jay Vasanth <jay.vasanth@microchip.com>
 Date: Tue, 8 Feb 2022 11:54:22 -0500
-Subject: [PATCH 030/112] [BACPORTED] Microchip: MEC172x: watchdog driver
+Subject: [PATCH 029/111] Microchip: MEC172x: watchdog driver
 
 Update wdt driver to support MEC172x device
 
@@ -10183,7 +9932,7 @@ Signed-off-by: Jay Vasanth <jay.vasanth@microchip.com>
  4 files changed, 82 insertions(+), 26 deletions(-)
 
 diff --git a/drivers/watchdog/wdt_mchp_xec.c b/drivers/watchdog/wdt_mchp_xec.c
-index 9546064485..f46e653b57 100644
+index 954606448..f46e653b5 100644
 --- a/drivers/watchdog/wdt_mchp_xec.c
 +++ b/drivers/watchdog/wdt_mchp_xec.c
 @@ -16,8 +16,14 @@ LOG_MODULE_REGISTER(wdt_mchp_xec);
@@ -10386,7 +10135,7 @@ index 9546064485..f46e653b57 100644
  		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
  		    &wdt_xec_api);
 diff --git a/dts/arm/microchip/mec1501hsz.dtsi b/dts/arm/microchip/mec1501hsz.dtsi
-index e930ac5d30..4448dd4fa4 100644
+index e930ac5d3..4448dd4fa 100644
 --- a/dts/arm/microchip/mec1501hsz.dtsi
 +++ b/dts/arm/microchip/mec1501hsz.dtsi
 @@ -95,6 +95,8 @@
@@ -10399,7 +10148,7 @@ index e930ac5d30..4448dd4fa4 100644
  		};
  		uart0: uart@400f2400 {
 diff --git a/dts/arm/microchip/mec172xnsz.dtsi b/dts/arm/microchip/mec172xnsz.dtsi
-index 0d45a2467c..4cf09720c0 100644
+index 0d45a2467..4cf09720c 100644
 --- a/dts/arm/microchip/mec172xnsz.dtsi
 +++ b/dts/arm/microchip/mec172xnsz.dtsi
 @@ -354,6 +354,7 @@
@@ -10411,7 +10160,7 @@ index 0d45a2467c..4cf09720c0 100644
  			interrupts = <171 0>;
  			girqs = <21 2>;
 diff --git a/dts/bindings/watchdog/microchip,xec-watchdog.yaml b/dts/bindings/watchdog/microchip,xec-watchdog.yaml
-index c7a7c41242..9823039e9d 100644
+index c7a7c4124..9823039e9 100644
 --- a/dts/bindings/watchdog/microchip,xec-watchdog.yaml
 +++ b/dts/bindings/watchdog/microchip,xec-watchdog.yaml
 @@ -16,3 +16,29 @@ properties:
@@ -10445,13 +10194,13 @@ index c7a7c41242..9823039e9d 100644
 +    - reg_index
 +    - bitpos
 -- 
-2.17.1
+2.25.1
 
 
-From b5f34aaa7528633dc23ab822ca60158dc8f04805 Mon Sep 17 00:00:00 2001
+From 5406a47335f58ced92babd12a786da16abda7eae Mon Sep 17 00:00:00 2001
 From: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>
 Date: Tue, 10 Aug 2021 11:17:46 +0200
-Subject: [PATCH 031/112] [BACPORTED] drivers: pinctrl: initial skeleton
+Subject: [PATCH 030/111] drivers: pinctrl: initial skeleton
 
 Initial skeleton for pinctrl drivers. This patch includes common
 infrastructure and API definitions for pinctrl drivers.
@@ -10473,7 +10222,7 @@ Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>
  create mode 100644 include/drivers/pinctrl.h
 
 diff --git a/drivers/CMakeLists.txt b/drivers/CMakeLists.txt
-index ce280174dd..182060d739 100644
+index ce280174d..182060d73 100644
 --- a/drivers/CMakeLists.txt
 +++ b/drivers/CMakeLists.txt
 @@ -61,3 +61,4 @@ add_subdirectory_ifdef(CONFIG_CACHE_MANAGEMENT cache)
@@ -10482,7 +10231,7 @@ index ce280174dd..182060d739 100644
  add_subdirectory_ifdef(CONFIG_FPGA             fpga)
 +add_subdirectory_ifdef(CONFIG_PINCTRL pinctrl)
 diff --git a/drivers/Kconfig b/drivers/Kconfig
-index e70c0c15e5..c21e9a2929 100644
+index e70c0c15e..c21e9a292 100644
 --- a/drivers/Kconfig
 +++ b/drivers/Kconfig
 @@ -123,4 +123,6 @@ source "drivers/bbram/Kconfig"
@@ -10494,7 +10243,7 @@ index e70c0c15e5..c21e9a2929 100644
  endmenu
 diff --git a/drivers/pinctrl/CMakeLists.txt b/drivers/pinctrl/CMakeLists.txt
 new file mode 100644
-index 0000000000..cd3eca95d8
+index 000000000..cd3eca95d
 --- /dev/null
 +++ b/drivers/pinctrl/CMakeLists.txt
 @@ -0,0 +1,5 @@
@@ -10505,7 +10254,7 @@ index 0000000000..cd3eca95d8
 +zephyr_library_sources(common.c)
 diff --git a/drivers/pinctrl/Kconfig b/drivers/pinctrl/Kconfig
 new file mode 100644
-index 0000000000..f1bfebb985
+index 000000000..f1bfebb98
 --- /dev/null
 +++ b/drivers/pinctrl/Kconfig
 @@ -0,0 +1,24 @@
@@ -10535,7 +10284,7 @@ index 0000000000..f1bfebb985
 +endif # PINCTRL
 diff --git a/drivers/pinctrl/common.c b/drivers/pinctrl/common.c
 new file mode 100644
-index 0000000000..a34eab3889
+index 000000000..a34eab388
 --- /dev/null
 +++ b/drivers/pinctrl/common.c
 @@ -0,0 +1,22 @@
@@ -10563,7 +10312,7 @@ index 0000000000..a34eab3889
 +}
 diff --git a/dts/bindings/pinctrl/pinctrl-device.yaml b/dts/bindings/pinctrl/pinctrl-device.yaml
 new file mode 100644
-index 0000000000..40679dbac6
+index 000000000..40679dbac
 --- /dev/null
 +++ b/dts/bindings/pinctrl/pinctrl-device.yaml
 @@ -0,0 +1,43 @@
@@ -10612,7 +10361,7 @@ index 0000000000..40679dbac6
 +      number of states.
 diff --git a/include/drivers/pinctrl.h b/include/drivers/pinctrl.h
 new file mode 100644
-index 0000000000..1c7646c7ca
+index 000000000..1c7646c7c
 --- /dev/null
 +++ b/include/drivers/pinctrl.h
 @@ -0,0 +1,330 @@
@@ -10947,13 +10696,13 @@ index 0000000000..1c7646c7ca
 +
 +#endif /* ZEPHYR_INCLUDE_DRIVERS_PINCTRL_H_ */
 -- 
-2.17.1
+2.25.1
 
 
-From 942d72b9b3dc4ba0c2b74b9a76bc3a7d7781c859 Mon Sep 17 00:00:00 2001
+From f20b4c4aaf77b771bf98f8dde90e794574a498d9 Mon Sep 17 00:00:00 2001
 From: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>
 Date: Thu, 2 Sep 2021 23:13:54 +0200
-Subject: [PATCH 032/112] [BACPORTED] drivers: pinctrl: allow to skip states
+Subject: [PATCH 031/111] drivers: pinctrl: allow to skip states
 
 If a certain state has to be skipped, a macro named
 Z_PINCTRL_SKIP_<STATE> can be defined evaluating to 1. This can be
@@ -10966,7 +10715,7 @@ Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>
  1 file changed, 28 insertions(+), 5 deletions(-)
 
 diff --git a/include/drivers/pinctrl.h b/include/drivers/pinctrl.h
-index 1c7646c7ca..f8b6b3ff23 100644
+index 1c7646c7c..f8b6b3ff2 100644
 --- a/include/drivers/pinctrl.h
 +++ b/include/drivers/pinctrl.h
 @@ -74,6 +74,11 @@ struct pinctrl_dev_config {
@@ -11043,14 +10792,13 @@ index 1c7646c7ca..f8b6b3ff23 100644
   * @param node_id Node identifier.
   */
 -- 
-2.17.1
+2.25.1
 
 
-From b5f761fe0f25bfc3eb005d48e0e259b9f04b691a Mon Sep 17 00:00:00 2001
+From 4ddb30b1e34b87e30038b579ddd26e6fab44c9ef Mon Sep 17 00:00:00 2001
 From: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>
 Date: Mon, 13 Sep 2021 16:30:58 +0200
-Subject: [PATCH 033/112] [BACPORTED] drivers: pinctrl: add support for dynamic
- pin control
+Subject: [PATCH 032/111] drivers: pinctrl: add support for dynamic pin control
 
 Add support for dynamic pin control, that is, allow to change device pin
 configuration at runtime. Because no device de-initialization is
@@ -11065,7 +10813,7 @@ Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>
  3 files changed, 150 insertions(+), 6 deletions(-)
 
 diff --git a/drivers/pinctrl/Kconfig b/drivers/pinctrl/Kconfig
-index f1bfebb985..7e1a67175b 100644
+index f1bfebb98..7e1a67175 100644
 --- a/drivers/pinctrl/Kconfig
 +++ b/drivers/pinctrl/Kconfig
 @@ -21,4 +21,12 @@ config PINCTRL_NON_STATIC
@@ -11082,7 +10830,7 @@ index f1bfebb985..7e1a67175b 100644
 +
  endif # PINCTRL
 diff --git a/drivers/pinctrl/common.c b/drivers/pinctrl/common.c
-index a34eab3889..d2d2652910 100644
+index a34eab388..d2d265291 100644
 --- a/drivers/pinctrl/common.c
 +++ b/drivers/pinctrl/common.c
 @@ -20,3 +20,36 @@ int pinctrl_lookup_state(const struct pinctrl_dev_config *config, uint8_t id,
@@ -11123,7 +10871,7 @@ index a34eab3889..d2d2652910 100644
 +}
 +#endif /* CONFIG_PINCTRL_DYNAMIC */
 diff --git a/include/drivers/pinctrl.h b/include/drivers/pinctrl.h
-index f8b6b3ff23..b8a429c240 100644
+index f8b6b3ff2..b8a429c24 100644
 --- a/include/drivers/pinctrl.h
 +++ b/include/drivers/pinctrl.h
 @@ -197,22 +197,29 @@ struct pinctrl_dev_config {
@@ -11275,14 +11023,13 @@ index f8b6b3ff23..b8a429c240 100644
  }
  #endif
 -- 
-2.17.1
+2.25.1
 
 
-From 40adc00c172977e2a74416be9a3270ab332cb22e Mon Sep 17 00:00:00 2001
+From 8e323f16287e3789d6040bff0db3ef5f66564cbf Mon Sep 17 00:00:00 2001
 From: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>
 Date: Wed, 6 Oct 2021 15:43:51 +0200
-Subject: [PATCH 034/112] [BACPORTED] dts: bindings: pinctrl: add
- pincfg-node-group
+Subject: [PATCH 033/111] dts: bindings: pinctrl: add pincfg-node-group
 
 When using group based representation on pinctrl nodes, the pin
 configuration properties end up being at the grand-children level, so
@@ -11300,7 +11047,7 @@ Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>
 
 diff --git a/dts/bindings/pinctrl/pincfg-node-group.yaml b/dts/bindings/pinctrl/pincfg-node-group.yaml
 new file mode 100644
-index 0000000000..09ec77d307
+index 000000000..09ec77d30
 --- /dev/null
 +++ b/dts/bindings/pinctrl/pincfg-node-group.yaml
 @@ -0,0 +1,165 @@
@@ -11470,14 +11217,13 @@ index 0000000000..09ec77d307
 +          before latching a value to an output pin. Typically indicates how
 +          many double-inverters are used to delay the signal.
 -- 
-2.17.1
+2.25.1
 
 
-From 44fa1123b1523fe1675564419d7fdc85f3a5ee3d Mon Sep 17 00:00:00 2001
+From f2d3f3b2f154d20be602d3ba445fda2ef3a3f894 Mon Sep 17 00:00:00 2001
 From: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>
 Date: Mon, 20 Sep 2021 14:27:06 +0200
-Subject: [PATCH 035/112] [BACPORTED] tests: drivers: pinctrl: add tests for
- API
+Subject: [PATCH 034/111] tests: drivers: pinctrl: add tests for API
 
 Add a set of tests to check the API behavior. The API tests can only run
 on a platform that does not have an actual pinctrl driver, e.g.
@@ -11518,7 +11264,7 @@ Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>
 
 diff --git a/dts/bindings/test/vnd,pinctrl-device.yaml b/dts/bindings/test/vnd,pinctrl-device.yaml
 new file mode 100644
-index 0000000000..3f8e18c88b
+index 000000000..3f8e18c88
 --- /dev/null
 +++ b/dts/bindings/test/vnd,pinctrl-device.yaml
 @@ -0,0 +1,8 @@
@@ -11532,7 +11278,7 @@ index 0000000000..3f8e18c88b
 +include: [base.yaml, pinctrl-device.yaml]
 diff --git a/dts/bindings/test/vnd,pinctrl-test.yaml b/dts/bindings/test/vnd,pinctrl-test.yaml
 new file mode 100644
-index 0000000000..d0c74ac236
+index 000000000..d0c74ac23
 --- /dev/null
 +++ b/dts/bindings/test/vnd,pinctrl-test.yaml
 @@ -0,0 +1,59 @@
@@ -11597,7 +11343,7 @@ index 0000000000..d0c74ac236
 +          purposes.
 diff --git a/tests/drivers/pinctrl/api/CMakeLists.txt b/tests/drivers/pinctrl/api/CMakeLists.txt
 new file mode 100644
-index 0000000000..1825c3dabc
+index 000000000..1825c3dab
 --- /dev/null
 +++ b/tests/drivers/pinctrl/api/CMakeLists.txt
 @@ -0,0 +1,12 @@
@@ -11615,7 +11361,7 @@ index 0000000000..1825c3dabc
 +target_sources(app PRIVATE src/main.c src/pinctrl_test.c ../common/test_device.c)
 diff --git a/tests/drivers/pinctrl/api/Kconfig b/tests/drivers/pinctrl/api/Kconfig
 new file mode 100644
-index 0000000000..8102053cdb
+index 000000000..8102053cd
 --- /dev/null
 +++ b/tests/drivers/pinctrl/api/Kconfig
 @@ -0,0 +1,13 @@
@@ -11634,7 +11380,7 @@ index 0000000000..8102053cdb
 +	  register address of devices.
 diff --git a/tests/drivers/pinctrl/api/app.overlay b/tests/drivers/pinctrl/api/app.overlay
 new file mode 100644
-index 0000000000..d406814b84
+index 000000000..d406814b8
 --- /dev/null
 +++ b/tests/drivers/pinctrl/api/app.overlay
 @@ -0,0 +1,92 @@
@@ -11732,7 +11478,7 @@ index 0000000000..d406814b84
 +};
 diff --git a/tests/drivers/pinctrl/api/prj.conf b/tests/drivers/pinctrl/api/prj.conf
 new file mode 100644
-index 0000000000..0ffb301538
+index 000000000..0ffb30153
 --- /dev/null
 +++ b/tests/drivers/pinctrl/api/prj.conf
 @@ -0,0 +1,7 @@
@@ -11745,7 +11491,7 @@ index 0000000000..0ffb301538
 +CONFIG_PINCTRL_DYNAMIC=y
 diff --git a/tests/drivers/pinctrl/api/reg.conf b/tests/drivers/pinctrl/api/reg.conf
 new file mode 100644
-index 0000000000..955bd02ea4
+index 000000000..955bd02ea
 --- /dev/null
 +++ b/tests/drivers/pinctrl/api/reg.conf
 @@ -0,0 +1,4 @@
@@ -11755,7 +11501,7 @@ index 0000000000..955bd02ea4
 +CONFIG_PINCTRL_TEST_STORE_REG=y
 diff --git a/tests/drivers/pinctrl/api/src/main.c b/tests/drivers/pinctrl/api/src/main.c
 new file mode 100644
-index 0000000000..3f331b9f1a
+index 000000000..3f331b9f1
 --- /dev/null
 +++ b/tests/drivers/pinctrl/api/src/main.c
 @@ -0,0 +1,171 @@
@@ -11932,7 +11678,7 @@ index 0000000000..3f331b9f1a
 +}
 diff --git a/tests/drivers/pinctrl/api/src/pinctrl_soc.h b/tests/drivers/pinctrl/api/src/pinctrl_soc.h
 new file mode 100644
-index 0000000000..85195c2f31
+index 000000000..85195c2f3
 --- /dev/null
 +++ b/tests/drivers/pinctrl/api/src/pinctrl_soc.h
 @@ -0,0 +1,100 @@
@@ -12038,7 +11784,7 @@ index 0000000000..85195c2f31
 +#endif /* ZEPHYR_TESTS_DRIVERS_PINCTRL_API_SRC_PINCTRL_SOC_H_ */
 diff --git a/tests/drivers/pinctrl/api/src/pinctrl_test.c b/tests/drivers/pinctrl/api/src/pinctrl_test.c
 new file mode 100644
-index 0000000000..0dff842f27
+index 000000000..0dff842f2
 --- /dev/null
 +++ b/tests/drivers/pinctrl/api/src/pinctrl_test.c
 @@ -0,0 +1,20 @@
@@ -12064,7 +11810,7 @@ index 0000000000..0dff842f27
 +}
 diff --git a/tests/drivers/pinctrl/api/testcase.yaml b/tests/drivers/pinctrl/api/testcase.yaml
 new file mode 100644
-index 0000000000..f56eb6a56f
+index 000000000..f56eb6a56
 --- /dev/null
 +++ b/tests/drivers/pinctrl/api/testcase.yaml
 @@ -0,0 +1,11 @@
@@ -12081,7 +11827,7 @@ index 0000000000..f56eb6a56f
 +    extra_args: CONF_FILE="prj.conf;reg.conf"
 diff --git a/tests/drivers/pinctrl/common/test_device.c b/tests/drivers/pinctrl/common/test_device.c
 new file mode 100644
-index 0000000000..827e475775
+index 000000000..827e47577
 --- /dev/null
 +++ b/tests/drivers/pinctrl/common/test_device.c
 @@ -0,0 +1,28 @@
@@ -12115,7 +11861,7 @@ index 0000000000..827e475775
 +DT_INST_FOREACH_STATUS_OKAY(PINCTRL_DEVICE_INIT)
 diff --git a/tests/drivers/pinctrl/common/test_device.h b/tests/drivers/pinctrl/common/test_device.h
 new file mode 100644
-index 0000000000..769465ce8c
+index 000000000..769465ce8
 --- /dev/null
 +++ b/tests/drivers/pinctrl/common/test_device.h
 @@ -0,0 +1,15 @@
@@ -12135,13 +11881,13 @@ index 0000000000..769465ce8c
 +
 +#endif /* ZEPHYR_TESTS_DRIVERS_PINCTRL_COMMON_TEST_DEVICE_H_ */
 -- 
-2.17.1
+2.25.1
 
 
-From c8380c6529560ca034ea10b33d2b4f7328fafd8a Mon Sep 17 00:00:00 2001
+From ffc06757019fd3c939fbfbe6e8c04eb84763d4f7 Mon Sep 17 00:00:00 2001
 From: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>
 Date: Thu, 16 Sep 2021 19:09:58 +0200
-Subject: [PATCH 036/112] [BACPORTED] doc: reference: add pinctrl API
+Subject: [PATCH 035/111] doc: reference: add pinctrl API
 
 Add pinctrl API documentation to the reference guides.
 
@@ -12154,7 +11900,7 @@ Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>
  create mode 100644 doc/reference/pinctrl/index.rst
 
 diff --git a/doc/reference/api/overview.rst b/doc/reference/api/overview.rst
-index 231e56fea2..2e61009da7 100644
+index 231e56fea..2e61009da 100644
 --- a/doc/reference/api/overview.rst
 +++ b/doc/reference/api/overview.rst
 @@ -232,6 +232,11 @@ current :ref:`stability level <api_lifecycle>`.
@@ -12170,7 +11916,7 @@ index 231e56fea2..2e61009da7 100644
       - Stable
       - 1.0
 diff --git a/doc/reference/index.rst b/doc/reference/index.rst
-index d77a8d2078..28499be390 100644
+index d77a8d207..28499be39 100644
 --- a/doc/reference/index.rst
 +++ b/doc/reference/index.rst
 @@ -27,6 +27,7 @@ API Reference
@@ -12183,7 +11929,7 @@ index d77a8d2078..28499be390 100644
     resource_management/index.rst
 diff --git a/doc/reference/pinctrl/index.rst b/doc/reference/pinctrl/index.rst
 new file mode 100644
-index 0000000000..cf2a5ab44c
+index 000000000..cf2a5ab44
 --- /dev/null
 +++ b/doc/reference/pinctrl/index.rst
 @@ -0,0 +1,11 @@
@@ -12199,13 +11945,13 @@ index 0000000000..cf2a5ab44c
 +
 +.. doxygengroup:: pinctrl_interface_dynamic
 -- 
-2.17.1
+2.25.1
 
 
-From b27e7464e1c0d6c9555a0f04330609be515c217e Mon Sep 17 00:00:00 2001
+From 52098a82b7cf0db844fd5fd87b922ffb307d545d Mon Sep 17 00:00:00 2001
 From: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>
 Date: Wed, 22 Sep 2021 22:44:00 +0200
-Subject: [PATCH 037/112] [BACPORTED] doc: enable figures enumeration
+Subject: [PATCH 036/111] doc: enable figures enumeration
 
 Enable figures enumeration. This option allows to use :numref: in order
 to reference figures, thus allowing more precise references other than
@@ -12217,7 +11963,7 @@ Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>
  1 file changed, 2 insertions(+)
 
 diff --git a/doc/conf.py b/doc/conf.py
-index dd70d72d43..cfc57a637c 100644
+index dd70d72d4..cfc57a637 100644
 --- a/doc/conf.py
 +++ b/doc/conf.py
 @@ -108,6 +108,8 @@ pygments_style = "sphinx"
@@ -12230,13 +11976,13 @@ index dd70d72d43..cfc57a637c 100644
  .. include:: /substitutions.txt
  """
 -- 
-2.17.1
+2.25.1
 
 
-From 40eb7f254ed9fdb3ffc8101cf9bc7644574edd55 Mon Sep 17 00:00:00 2001
+From fb698e80d1ef4d150600fe141c7959c3f4511286 Mon Sep 17 00:00:00 2001
 From: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>
 Date: Wed, 22 Sep 2021 23:12:58 +0200
-Subject: [PATCH 038/112] [BACPORTED] doc: guides: add pinctrl guide
+Subject: [PATCH 037/111] doc: guides: add pinctrl guide
 
 Add a user guide that provides general concepts on pin control, details
 on Zephyr model, implementation guidelines, etc.
@@ -12257,7 +12003,7 @@ Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>
  create mode 100644 doc/guides/pinctrl/index.rst
 
 diff --git a/doc/guides/index.rst b/doc/guides/index.rst
-index bed597a70e..7041ed4edb 100644
+index bed597a70..7041ed4ed 100644
 --- a/doc/guides/index.rst
 +++ b/doc/guides/index.rst
 @@ -17,6 +17,7 @@ User and Developer Guides
@@ -12559,7 +12305,7 @@ HcmV?d00001
 
 diff --git a/doc/guides/pinctrl/images/hw-cent-control.svg b/doc/guides/pinctrl/images/hw-cent-control.svg
 new file mode 100644
-index 0000000000..571e90f134
+index 000000000..571e90f13
 --- /dev/null
 +++ b/doc/guides/pinctrl/images/hw-cent-control.svg
 @@ -0,0 +1,905 @@
@@ -13782,7 +13528,7 @@ HcmV?d00001
 
 diff --git a/doc/guides/pinctrl/images/hw-dist-control.svg b/doc/guides/pinctrl/images/hw-dist-control.svg
 new file mode 100644
-index 0000000000..0030d75fc9
+index 000000000..0030d75fc
 --- /dev/null
 +++ b/doc/guides/pinctrl/images/hw-dist-control.svg
 @@ -0,0 +1,1198 @@
@@ -14987,7 +14733,7 @@ index 0000000000..0030d75fc9
 \ No newline at end of file
 diff --git a/doc/guides/pinctrl/index.rst b/doc/guides/pinctrl/index.rst
 new file mode 100644
-index 0000000000..40e80235a6
+index 000000000..40e80235a
 --- /dev/null
 +++ b/doc/guides/pinctrl/index.rst
 @@ -0,0 +1,492 @@
@@ -15484,13 +15230,13 @@ index 0000000000..40e80235a6
 +
 +- `Introduction to pin muxing and GPIO control under Linux <https://static.sched.com/hosted_files/osselc21/b6/ELC-2021_Introduction_to_pin_muxing_and_GPIO_control_under_Linux.pdf>`_
 -- 
-2.17.1
+2.25.1
 
 
-From 8da267e05a4243b62120131ba10195e34d0c0c79 Mon Sep 17 00:00:00 2001
+From 0d152fe0d0bffb2a59687b504c84345cc62516c1 Mon Sep 17 00:00:00 2001
 From: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>
 Date: Wed, 15 Sep 2021 16:34:37 +0200
-Subject: [PATCH 039/112] [BACPORTED] CODEOWNERS: add myself to pinctrl
+Subject: [PATCH 038/111] CODEOWNERS: add myself to pinctrl
 
 Add myself as code owner for pinctrl drivers.
 
@@ -15500,7 +15246,7 @@ Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>
  1 file changed, 1 insertion(+)
 
 diff --git a/CODEOWNERS b/CODEOWNERS
-index b441aa4e6e..756307b6f0 100644
+index b441aa4e6..756307b6f 100644
 --- a/CODEOWNERS
 +++ b/CODEOWNERS
 @@ -284,6 +284,7 @@
@@ -15512,14 +15258,13 @@ index b441aa4e6e..756307b6f0 100644
  /drivers/pinmux/*hsdk*                    @iriszzw
  /drivers/pinmux/*it8xxx2*                 @ite
 -- 
-2.17.1
+2.25.1
 
 
-From 64071400803509f48b50ca9a50f08da2a60bebfe Mon Sep 17 00:00:00 2001
+From e2fbf8c758cce87bd544677a16382893c1f1500c Mon Sep 17 00:00:00 2001
 From: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>
 Date: Mon, 6 Sep 2021 15:45:34 +0200
-Subject: [PATCH 040/112] [BACPORTED] device: add DEVICE_DT_GET_OR_NULL utility
- macro
+Subject: [PATCH 039/111] device: add DEVICE_DT_GET_OR_NULL utility macro
 
 Add a new utility macro to obtain an optional reference to a device. If
 the provided node_id is not enabled, the macro falls back to NULL.
@@ -15530,7 +15275,7 @@ Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>
  1 file changed, 13 insertions(+)
 
 diff --git a/include/device.h b/include/device.h
-index c88316779d..87599d6086 100644
+index c88316779..87599d608 100644
 --- a/include/device.h
 +++ b/include/device.h
 @@ -301,6 +301,19 @@ typedef int16_t device_handle_t;
@@ -15554,14 +15299,13 @@ index c88316779d..87599d6086 100644
   * @def DEVICE_GET
   *
 -- 
-2.17.1
+2.25.1
 
 
-From db10156082039f288014370f59ff96642c502896 Mon Sep 17 00:00:00 2001
+From e1452b4229e19a2c192febf33807e6b1b00e5702 Mon Sep 17 00:00:00 2001
 From: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>
 Date: Mon, 6 Sep 2021 15:46:57 +0200
-Subject: [PATCH 041/112] [BACPORTED] drivers: pinmux: stm32: use
- DEVICE_DT_GET_OR_NULL
+Subject: [PATCH 040/111] drivers: pinmux: stm32: use DEVICE_DT_GET_OR_NULL
 
 Use existing Devicetree macro to obtain optional references to GPIO
 ports.
@@ -15572,7 +15316,7 @@ Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>
  1 file changed, 11 insertions(+), 16 deletions(-)
 
 diff --git a/drivers/pinmux/pinmux_stm32.c b/drivers/pinmux/pinmux_stm32.c
-index 65c9d1bf51..c9ce59e86e 100644
+index 65c9d1bf5..c9ce59e86 100644
 --- a/drivers/pinmux/pinmux_stm32.c
 +++ b/drivers/pinmux/pinmux_stm32.c
 @@ -24,23 +24,18 @@
@@ -15611,14 +15355,14 @@ index 65c9d1bf51..c9ce59e86e 100644
  
  static int stm32_pin_configure(uint32_t pin, uint32_t func, uint32_t altf)
 -- 
-2.17.1
+2.25.1
 
 
-From 287e668ec0fc12219e2f4db1749ba80afdc53c71 Mon Sep 17 00:00:00 2001
+From 46b00ef44201272058f5c4a441d8b3b11a96f29a Mon Sep 17 00:00:00 2001
 From: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>
 Date: Mon, 3 Jan 2022 18:43:29 +0100
-Subject: [PATCH 042/112] [BACPORTED] soc: arm: nuvoton_npcx: make soc_*.h
- headers self-contained
+Subject: [PATCH 041/111] soc: arm: nuvoton_npcx: make soc_*.h headers
+ self-contained
 
 Almost none of the soc_*.h headers were self-contained. This patch adds
 all necessary includes to improve the situation.
@@ -15636,7 +15380,7 @@ Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>
  8 files changed, 32 insertions(+), 1 deletion(-)
 
 diff --git a/soc/arm/nuvoton_npcx/common/reg/reg_def.h b/soc/arm/nuvoton_npcx/common/reg/reg_def.h
-index 65ffa677b5..471deda03d 100644
+index 65ffa677b..471deda03 100644
 --- a/soc/arm/nuvoton_npcx/common/reg/reg_def.h
 +++ b/soc/arm/nuvoton_npcx/common/reg/reg_def.h
 @@ -7,6 +7,12 @@
@@ -15653,7 +15397,7 @@ index 65ffa677b5..471deda03d 100644
   * NPCX register structure size/offset checking macro function to mitigate
   * the risk of unexpected compiling results. All addresses of NPCX registers
 diff --git a/soc/arm/nuvoton_npcx/common/soc_clock.h b/soc/arm/nuvoton_npcx/common/soc_clock.h
-index 19892ac988..f02bb7d989 100644
+index 19892ac98..f02bb7d98 100644
 --- a/soc/arm/nuvoton_npcx/common/soc_clock.h
 +++ b/soc/arm/nuvoton_npcx/common/soc_clock.h
 @@ -7,6 +7,11 @@
@@ -15669,7 +15413,7 @@ index 19892ac988..f02bb7d989 100644
  extern "C" {
  #endif
 diff --git a/soc/arm/nuvoton_npcx/common/soc_dt.h b/soc/arm/nuvoton_npcx/common/soc_dt.h
-index 076546a279..0b9a2ed65f 100644
+index 076546a27..0b9a2ed65 100644
 --- a/soc/arm/nuvoton_npcx/common/soc_dt.h
 +++ b/soc/arm/nuvoton_npcx/common/soc_dt.h
 @@ -7,6 +7,10 @@
@@ -15684,7 +15428,7 @@ index 076546a279..0b9a2ed65f 100644
   * @brief Like DT_PROP(), but expand parameters with
   *        DT_ENUM_UPPER_TOKEN not DT_PROP
 diff --git a/soc/arm/nuvoton_npcx/common/soc_espi.h b/soc/arm/nuvoton_npcx/common/soc_espi.h
-index 2d75f13f0d..b577aacf78 100644
+index 2d75f13f0..b577aacf7 100644
 --- a/soc/arm/nuvoton_npcx/common/soc_espi.h
 +++ b/soc/arm/nuvoton_npcx/common/soc_espi.h
 @@ -8,7 +8,6 @@
@@ -15696,7 +15440,7 @@ index 2d75f13f0d..b577aacf78 100644
  #ifdef __cplusplus
  extern "C" {
 diff --git a/soc/arm/nuvoton_npcx/common/soc_gpio.h b/soc/arm/nuvoton_npcx/common/soc_gpio.h
-index bf36245c04..5d29a4ce21 100644
+index bf36245c0..5d29a4ce2 100644
 --- a/soc/arm/nuvoton_npcx/common/soc_gpio.h
 +++ b/soc/arm/nuvoton_npcx/common/soc_gpio.h
 @@ -7,6 +7,8 @@
@@ -15709,7 +15453,7 @@ index bf36245c04..5d29a4ce21 100644
  extern "C" {
  #endif
 diff --git a/soc/arm/nuvoton_npcx/common/soc_host.h b/soc/arm/nuvoton_npcx/common/soc_host.h
-index b7f5e94f71..11be222526 100644
+index b7f5e94f7..11be22252 100644
 --- a/soc/arm/nuvoton_npcx/common/soc_host.h
 +++ b/soc/arm/nuvoton_npcx/common/soc_host.h
 @@ -7,6 +7,12 @@
@@ -15726,7 +15470,7 @@ index b7f5e94f71..11be222526 100644
  extern "C" {
  #endif
 diff --git a/soc/arm/nuvoton_npcx/common/soc_miwu.h b/soc/arm/nuvoton_npcx/common/soc_miwu.h
-index 7526667f29..fad42ee4ac 100644
+index 7526667f2..fad42ee4a 100644
 --- a/soc/arm/nuvoton_npcx/common/soc_miwu.h
 +++ b/soc/arm/nuvoton_npcx/common/soc_miwu.h
 @@ -7,6 +7,11 @@
@@ -15742,7 +15486,7 @@ index 7526667f29..fad42ee4ac 100644
  extern "C" {
  #endif
 diff --git a/soc/arm/nuvoton_npcx/common/soc_pins.h b/soc/arm/nuvoton_npcx/common/soc_pins.h
-index 53002daebf..a136f24890 100644
+index 53002daeb..a136f2489 100644
 --- a/soc/arm/nuvoton_npcx/common/soc_pins.h
 +++ b/soc/arm/nuvoton_npcx/common/soc_pins.h
 @@ -7,6 +7,10 @@
@@ -15757,14 +15501,14 @@ index 53002daebf..a136f24890 100644
  extern "C" {
  #endif
 -- 
-2.17.1
+2.25.1
 
 
-From 4449a5ee5f74a78858cbb50d93f1b0823c88e014 Mon Sep 17 00:00:00 2001
+From 8574c78e7692bf904319264bab20ad106d5f59d2 Mon Sep 17 00:00:00 2001
 From: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>
 Date: Mon, 3 Jan 2022 18:49:52 +0100
-Subject: [PATCH 043/112] [BACPORTED] soc: arm: atmel_sam0: common: soc_port:
- add missing include
+Subject: [PATCH 042/111] soc: arm: atmel_sam0: common: soc_port: add missing
+ include
 
 The source file uses boolean types internally, however, <stdbool.h> was
 not included. It was likely included indirectly before via
@@ -15776,7 +15520,7 @@ Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>
  1 file changed, 2 insertions(+)
 
 diff --git a/soc/arm/atmel_sam0/common/soc_port.c b/soc/arm/atmel_sam0/common/soc_port.c
-index 996f913380..2508b5ed05 100644
+index 996f91338..2508b5ed0 100644
 --- a/soc/arm/atmel_sam0/common/soc_port.c
 +++ b/soc/arm/atmel_sam0/common/soc_port.c
 @@ -9,6 +9,8 @@
@@ -15789,14 +15533,14 @@ index 996f913380..2508b5ed05 100644
  
  int soc_port_pinmux_set(PortGroup *pg, uint32_t pin, uint32_t func)
 -- 
-2.17.1
+2.25.1
 
 
-From 26ec83ed2289d8be7325f05afde01a85df7a3f36 Mon Sep 17 00:00:00 2001
+From 39d8095547cb5c2b8c91ea6f611b32fca8229524 Mon Sep 17 00:00:00 2001
 From: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>
 Date: Mon, 3 Jan 2022 23:52:05 +0100
-Subject: [PATCH 044/112] [BACPORTED] soc: arm: silabs_exx32: make soc_pinmap.h
- self contained
+Subject: [PATCH 043/111] soc: arm: silabs_exx32: make soc_pinmap.h self
+ contained
 
 The soc_pinmap.h uses the DT API, so these headers needs to include
 <devicetree.h>.
@@ -15813,7 +15557,7 @@ Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>
  7 files changed, 7 insertions(+)
 
 diff --git a/soc/arm/silabs_exx32/efm32gg11b/soc_pinmap.h b/soc/arm/silabs_exx32/efm32gg11b/soc_pinmap.h
-index c52bf1740c..c1e960df74 100644
+index c52bf1740..c1e960df7 100644
 --- a/soc/arm/silabs_exx32/efm32gg11b/soc_pinmap.h
 +++ b/soc/arm/silabs_exx32/efm32gg11b/soc_pinmap.h
 @@ -15,6 +15,7 @@
@@ -15825,7 +15569,7 @@ index c52bf1740c..c1e960df74 100644
  #include <em_gpio.h>
  
 diff --git a/soc/arm/silabs_exx32/efm32jg12b/soc_pinmap.h b/soc/arm/silabs_exx32/efm32jg12b/soc_pinmap.h
-index 5dd7eb47ce..5e947578ee 100644
+index 5dd7eb47c..5e947578e 100644
 --- a/soc/arm/silabs_exx32/efm32jg12b/soc_pinmap.h
 +++ b/soc/arm/silabs_exx32/efm32jg12b/soc_pinmap.h
 @@ -13,6 +13,7 @@
@@ -15837,7 +15581,7 @@ index 5dd7eb47ce..5e947578ee 100644
  #include <em_gpio.h>
  
 diff --git a/soc/arm/silabs_exx32/efm32pg12b/soc_pinmap.h b/soc/arm/silabs_exx32/efm32pg12b/soc_pinmap.h
-index d073cfc91b..7765a26a74 100644
+index d073cfc91..7765a26a7 100644
 --- a/soc/arm/silabs_exx32/efm32pg12b/soc_pinmap.h
 +++ b/soc/arm/silabs_exx32/efm32pg12b/soc_pinmap.h
 @@ -13,6 +13,7 @@
@@ -15849,7 +15593,7 @@ index d073cfc91b..7765a26a74 100644
  #include <em_gpio.h>
  
 diff --git a/soc/arm/silabs_exx32/efm32pg1b/soc_pinmap.h b/soc/arm/silabs_exx32/efm32pg1b/soc_pinmap.h
-index 153faff8c1..8eea7121e1 100644
+index 153faff8c..8eea7121e 100644
 --- a/soc/arm/silabs_exx32/efm32pg1b/soc_pinmap.h
 +++ b/soc/arm/silabs_exx32/efm32pg1b/soc_pinmap.h
 @@ -13,6 +13,7 @@
@@ -15861,7 +15605,7 @@ index 153faff8c1..8eea7121e1 100644
  #include <em_gpio.h>
  
 diff --git a/soc/arm/silabs_exx32/efr32fg13p/soc_pinmap.h b/soc/arm/silabs_exx32/efr32fg13p/soc_pinmap.h
-index 0d802e4370..fa9731e2c8 100644
+index 0d802e437..fa9731e2c 100644
 --- a/soc/arm/silabs_exx32/efr32fg13p/soc_pinmap.h
 +++ b/soc/arm/silabs_exx32/efr32fg13p/soc_pinmap.h
 @@ -13,6 +13,7 @@
@@ -15873,7 +15617,7 @@ index 0d802e4370..fa9731e2c8 100644
  #include <em_gpio.h>
  
 diff --git a/soc/arm/silabs_exx32/efr32fg1p/soc_pinmap.h b/soc/arm/silabs_exx32/efr32fg1p/soc_pinmap.h
-index 83944e8b15..3688bd3348 100644
+index 83944e8b1..3688bd334 100644
 --- a/soc/arm/silabs_exx32/efr32fg1p/soc_pinmap.h
 +++ b/soc/arm/silabs_exx32/efr32fg1p/soc_pinmap.h
 @@ -13,6 +13,7 @@
@@ -15885,7 +15629,7 @@ index 83944e8b15..3688bd3348 100644
  #include <em_gpio.h>
  
 diff --git a/soc/arm/silabs_exx32/efr32mg12p/soc_pinmap.h b/soc/arm/silabs_exx32/efr32mg12p/soc_pinmap.h
-index a6de7301b2..5bc059a3a4 100644
+index a6de7301b..5bc059a3a 100644
 --- a/soc/arm/silabs_exx32/efr32mg12p/soc_pinmap.h
 +++ b/soc/arm/silabs_exx32/efr32mg12p/soc_pinmap.h
 @@ -13,6 +13,7 @@
@@ -15897,14 +15641,14 @@ index a6de7301b2..5bc059a3a4 100644
  
  #define GPIO_NODE DT_INST(0, silabs_gecko_gpio)
 -- 
-2.17.1
+2.25.1
 
 
-From 8b2fa50b3d93cb5818f2cceb08fe336519421c2a Mon Sep 17 00:00:00 2001
+From 7614780ede8321bfbf198b224e8c4864f5a90f51 Mon Sep 17 00:00:00 2001
 From: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>
 Date: Tue, 4 Jan 2022 09:53:08 +0100
-Subject: [PATCH 045/112] [BACPORTED] soc: riscv: riscv-privilege: andes_v5:
- make smu.h self contained
+Subject: [PATCH 044/111] soc: riscv: riscv-privilege: andes_v5: make smu.h
+ self contained
 
 The header was not self-contained: it uses DT and utility macros but
 <devicetree.h> and <sys/util_macro.h> were not included.
@@ -15915,7 +15659,7 @@ Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>
  1 file changed, 3 insertions(+)
 
 diff --git a/soc/riscv/riscv-privilege/andes_v5/smu.h b/soc/riscv/riscv-privilege/andes_v5/smu.h
-index 484beb7564..d4657124f9 100644
+index 484beb756..d4657124f 100644
 --- a/soc/riscv/riscv-privilege/andes_v5/smu.h
 +++ b/soc/riscv/riscv-privilege/andes_v5/smu.h
 @@ -11,6 +11,9 @@
@@ -15929,14 +15673,13 @@ index 484beb7564..d4657124f9 100644
   * SMU Register Base Address
   */
 -- 
-2.17.1
+2.25.1
 
 
-From 9d019d4ba27c87943591d24b63b490576f1ab242 Mon Sep 17 00:00:00 2001
+From c4bf77321c6f8ccb267bec552267aeb7a1424359 Mon Sep 17 00:00:00 2001
 From: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>
 Date: Tue, 4 Jan 2022 11:11:12 +0100
-Subject: [PATCH 046/112] [BACPORTED] soc: riscv: telink_b91: fix required
- headers
+Subject: [PATCH 045/111] soc: riscv: telink_b91: fix required headers
 
 The linker script is using the DT API, which was previously included via
 <soc.h>.
@@ -15947,7 +15690,7 @@ Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/soc/riscv/riscv-privilege/telink_b91/linker.ld b/soc/riscv/riscv-privilege/telink_b91/linker.ld
-index 09497397f5..85a9c6c2ee 100644
+index 09497397f..85a9c6c2e 100644
 --- a/soc/riscv/riscv-privilege/telink_b91/linker.ld
 +++ b/soc/riscv/riscv-privilege/telink_b91/linker.ld
 @@ -8,8 +8,8 @@
@@ -15961,14 +15704,14 @@ index 09497397f5..85a9c6c2ee 100644
  
  MEMORY
 -- 
-2.17.1
+2.25.1
 
 
-From 67f9906d7399ab7d0882c54b19c463827a8403a4 Mon Sep 17 00:00:00 2001
+From ce8788aade6604d1dac5bf8170534cbe5caa57a4 Mon Sep 17 00:00:00 2001
 From: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>
 Date: Mon, 3 Jan 2022 16:35:11 +0100
-Subject: [PATCH 047/112] [BACPORTED] arch: arm: aarch32: cortex_m: nvic: make
- header self-contained
+Subject: [PATCH 046/111] arch: arm: aarch32: cortex_m: nvic: make header
+ self-contained
 
 The header contains macros that make use of the Devicetree API, however,
 <devicetree.h> is not included. This was "mitigated" by most <soc.h>
@@ -15980,7 +15723,7 @@ Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>
  1 file changed, 2 insertions(+)
 
 diff --git a/include/arch/arm/aarch32/cortex_m/nvic.h b/include/arch/arm/aarch32/cortex_m/nvic.h
-index fa197c3928..5f1a5bff14 100644
+index fa197c392..5f1a5bff1 100644
 --- a/include/arch/arm/aarch32/cortex_m/nvic.h
 +++ b/include/arch/arm/aarch32/cortex_m/nvic.h
 @@ -7,6 +7,8 @@
@@ -15993,14 +15736,13 @@ index fa197c3928..5f1a5bff14 100644
  /* The order here is on purpose since ARMv8.1-M SoCs may define
   * CONFIG_ARMV6_M_ARMV8_M_BASELINE, CONFIG_ARMV7_M_ARMV8_M_MAINLINE or
 -- 
-2.17.1
+2.25.1
 
 
-From b659cbe372b70ca758a8cd1a9a550d4dcc2e4316 Mon Sep 17 00:00:00 2001
+From 2d1b06ee356698b43c987c34b9f57c93f5449edc Mon Sep 17 00:00:00 2001
 From: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>
 Date: Mon, 3 Jan 2022 16:43:09 +0100
-Subject: [PATCH 048/112] [BACPORTED] soc: remove unnecessary inclusions of
- devicetree.h
+Subject: [PATCH 047/111] soc: remove unnecessary inclusions of devicetree.h
 
 Many ARM SoCs included <devicetree.h> likely due to:
 
@@ -16075,7 +15817,7 @@ Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>
  54 files changed, 90 deletions(-)
 
 diff --git a/soc/arm/arm/beetle/soc.h b/soc/arm/arm/beetle/soc.h
-index 2d86750fa8..647bedc333 100644
+index 2d86750fa..647bedc33 100644
 --- a/soc/arm/arm/beetle/soc.h
 +++ b/soc/arm/arm/beetle/soc.h
 @@ -95,8 +95,6 @@
@@ -16088,7 +15830,7 @@ index 2d86750fa8..647bedc333 100644
  #include "soc_pins.h"
  #include "soc_power.h"
 diff --git a/soc/arm/arm/designstart/soc.h b/soc/arm/arm/designstart/soc.h
-index f58070378e..ec58467f92 100644
+index f58070378..ec58467f9 100644
 --- a/soc/arm/arm/designstart/soc.h
 +++ b/soc/arm/arm/designstart/soc.h
 @@ -7,7 +7,6 @@
@@ -16100,7 +15842,7 @@ index f58070378e..ec58467f92 100644
  #define __MPU_PRESENT CONFIG_CPU_HAS_ARM_MPU
  
 diff --git a/soc/arm/arm/mps2/soc.h b/soc/arm/arm/mps2/soc.h
-index 011fcf7cf1..594d3d084c 100644
+index 011fcf7cf..594d3d084 100644
 --- a/soc/arm/arm/mps2/soc.h
 +++ b/soc/arm/arm/mps2/soc.h
 @@ -16,7 +16,6 @@
@@ -16112,7 +15854,7 @@ index 011fcf7cf1..594d3d084c 100644
  
  extern void wakeup_cpu1(void);
 diff --git a/soc/arm/arm/mps3/soc.h b/soc/arm/arm/mps3/soc.h
-index fcecfcdd7f..bfa4a2a01b 100644
+index fcecfcdd7..bfa4a2a01 100644
 --- a/soc/arm/arm/mps3/soc.h
 +++ b/soc/arm/arm/mps3/soc.h
 @@ -17,6 +17,5 @@
@@ -16123,7 +15865,7 @@ index fcecfcdd7f..bfa4a2a01b 100644
  
  #endif /* _SOC_H_ */
 diff --git a/soc/arm/arm/musca_b1/soc.h b/soc/arm/arm/musca_b1/soc.h
-index 5223f3bb43..672c4852bc 100644
+index 5223f3bb4..672c4852b 100644
 --- a/soc/arm/arm/musca_b1/soc.h
 +++ b/soc/arm/arm/musca_b1/soc.h
 @@ -9,7 +9,6 @@
@@ -16135,7 +15877,7 @@ index 5223f3bb43..672c4852bc 100644
  #endif
  
 diff --git a/soc/arm/arm/musca_s1/soc.h b/soc/arm/arm/musca_s1/soc.h
-index a91e1c2e1c..a7934afd1f 100644
+index a91e1c2e1..a7934afd1 100644
 --- a/soc/arm/arm/musca_s1/soc.h
 +++ b/soc/arm/arm/musca_s1/soc.h
 @@ -9,7 +9,6 @@
@@ -16147,7 +15889,7 @@ index a91e1c2e1c..a7934afd1f 100644
  #endif
  
 diff --git a/soc/arm/atmel_sam/sam3x/soc.h b/soc/arm/atmel_sam/sam3x/soc.h
-index 9d12b4be1d..0d7842fac1 100644
+index 9d12b4be1..0d7842fac 100644
 --- a/soc/arm/atmel_sam/sam3x/soc.h
 +++ b/soc/arm/atmel_sam/sam3x/soc.h
 @@ -17,8 +17,6 @@
@@ -16160,7 +15902,7 @@ index 9d12b4be1d..0d7842fac1 100644
  #define DONT_USE_CMSIS_INIT
  #define DONT_USE_PREDEFINED_CORE_HANDLERS
 diff --git a/soc/arm/atmel_sam/sam4e/soc.h b/soc/arm/atmel_sam/sam4e/soc.h
-index ec8f4523c5..245cd05b7d 100644
+index ec8f4523c..245cd05b7 100644
 --- a/soc/arm/atmel_sam/sam4e/soc.h
 +++ b/soc/arm/atmel_sam/sam4e/soc.h
 @@ -19,8 +19,6 @@
@@ -16173,7 +15915,7 @@ index ec8f4523c5..245cd05b7d 100644
  #define DONT_USE_CMSIS_INIT
  #define DONT_USE_PREDEFINED_CORE_HANDLERS
 diff --git a/soc/arm/atmel_sam/sam4s/soc.h b/soc/arm/atmel_sam/sam4s/soc.h
-index e3f350d47a..e7c5561653 100644
+index e3f350d47..e7c556165 100644
 --- a/soc/arm/atmel_sam/sam4s/soc.h
 +++ b/soc/arm/atmel_sam/sam4s/soc.h
 @@ -19,8 +19,6 @@
@@ -16186,7 +15928,7 @@ index e3f350d47a..e7c5561653 100644
  #define DONT_USE_CMSIS_INIT
  #define DONT_USE_PREDEFINED_CORE_HANDLERS
 diff --git a/soc/arm/atmel_sam/same70/soc.h b/soc/arm/atmel_sam/same70/soc.h
-index b1b1eb176d..41078384df 100644
+index b1b1eb176..41078384d 100644
 --- a/soc/arm/atmel_sam/same70/soc.h
 +++ b/soc/arm/atmel_sam/same70/soc.h
 @@ -17,8 +17,6 @@
@@ -16199,7 +15941,7 @@ index b1b1eb176d..41078384df 100644
  #define DONT_USE_CMSIS_INIT
  #define DONT_USE_PREDEFINED_CORE_HANDLERS
 diff --git a/soc/arm/atmel_sam/samv71/soc.h b/soc/arm/atmel_sam/samv71/soc.h
-index 151a45b151..64e41ffa6d 100644
+index 151a45b15..64e41ffa6 100644
 --- a/soc/arm/atmel_sam/samv71/soc.h
 +++ b/soc/arm/atmel_sam/samv71/soc.h
 @@ -18,8 +18,6 @@
@@ -16212,7 +15954,7 @@ index 151a45b151..64e41ffa6d 100644
  #define DONT_USE_CMSIS_INIT
  #define DONT_USE_PREDEFINED_CORE_HANDLERS
 diff --git a/soc/arm/atmel_sam0/samd20/soc.h b/soc/arm/atmel_sam0/samd20/soc.h
-index 29c48ed458..ba85f7b440 100644
+index 29c48ed45..ba85f7b44 100644
 --- a/soc/arm/atmel_sam0/samd20/soc.h
 +++ b/soc/arm/atmel_sam0/samd20/soc.h
 @@ -13,8 +13,6 @@
@@ -16225,7 +15967,7 @@ index 29c48ed458..ba85f7b440 100644
  #if defined(CONFIG_SOC_PART_NUMBER_SAMD20E14)
  #include <samd20e14.h>
 diff --git a/soc/arm/atmel_sam0/samd21/soc.h b/soc/arm/atmel_sam0/samd21/soc.h
-index cd37dca0a0..ab0dc5f0f4 100644
+index cd37dca0a..ab0dc5f0f 100644
 --- a/soc/arm/atmel_sam0/samd21/soc.h
 +++ b/soc/arm/atmel_sam0/samd21/soc.h
 @@ -13,8 +13,6 @@
@@ -16238,7 +15980,7 @@ index cd37dca0a0..ab0dc5f0f4 100644
  #if defined(CONFIG_SOC_PART_NUMBER_SAMD21E15A)
  #include <samd21e15a.h>
 diff --git a/soc/arm/atmel_sam0/samd51/soc.h b/soc/arm/atmel_sam0/samd51/soc.h
-index 994f7db573..5834c2fadd 100644
+index 994f7db57..5834c2fad 100644
 --- a/soc/arm/atmel_sam0/samd51/soc.h
 +++ b/soc/arm/atmel_sam0/samd51/soc.h
 @@ -13,8 +13,6 @@
@@ -16251,7 +15993,7 @@ index 994f7db573..5834c2fadd 100644
  #if defined(CONFIG_SOC_PART_NUMBER_SAMD51G18A)
  #include <samd51g18a.h>
 diff --git a/soc/arm/atmel_sam0/same51/soc.h b/soc/arm/atmel_sam0/same51/soc.h
-index fe82f8eaf1..4ccece2ea5 100644
+index fe82f8eaf..4ccece2ea 100644
 --- a/soc/arm/atmel_sam0/same51/soc.h
 +++ b/soc/arm/atmel_sam0/same51/soc.h
 @@ -13,8 +13,6 @@
@@ -16264,7 +16006,7 @@ index fe82f8eaf1..4ccece2ea5 100644
  #if defined(CONFIG_SOC_PART_NUMBER_SAME51J18A)
  #include <same51j18a.h>
 diff --git a/soc/arm/atmel_sam0/same53/soc.h b/soc/arm/atmel_sam0/same53/soc.h
-index cb69d1512f..9aafc1756a 100644
+index cb69d1512..9aafc1756 100644
 --- a/soc/arm/atmel_sam0/same53/soc.h
 +++ b/soc/arm/atmel_sam0/same53/soc.h
 @@ -13,8 +13,6 @@
@@ -16277,7 +16019,7 @@ index cb69d1512f..9aafc1756a 100644
  #if defined(CONFIG_SOC_PART_NUMBER_SAME53J18A)
  #include <same53j18a.h>
 diff --git a/soc/arm/atmel_sam0/same54/soc.h b/soc/arm/atmel_sam0/same54/soc.h
-index 7312f3897b..5036a92f55 100644
+index 7312f3897..5036a92f5 100644
 --- a/soc/arm/atmel_sam0/same54/soc.h
 +++ b/soc/arm/atmel_sam0/same54/soc.h
 @@ -13,8 +13,6 @@
@@ -16290,7 +16032,7 @@ index 7312f3897b..5036a92f55 100644
  #if defined(CONFIG_SOC_PART_NUMBER_SAME54N19A)
  #include <same54n19a.h>
 diff --git a/soc/arm/atmel_sam0/samr21/soc.h b/soc/arm/atmel_sam0/samr21/soc.h
-index 8dbc88f23c..ecee8a6c2e 100644
+index 8dbc88f23..ecee8a6c2 100644
 --- a/soc/arm/atmel_sam0/samr21/soc.h
 +++ b/soc/arm/atmel_sam0/samr21/soc.h
 @@ -13,8 +13,6 @@
@@ -16303,7 +16045,7 @@ index 8dbc88f23c..ecee8a6c2e 100644
  #if defined(CONFIG_SOC_PART_NUMBER_SAMR21E16A)
  #include <samr21e16a.h>
 diff --git a/soc/arm/bcm_vk/valkyrie/soc.h b/soc/arm/bcm_vk/valkyrie/soc.h
-index fa254cbe0b..1a076a225f 100644
+index fa254cbe0..1a076a225 100644
 --- a/soc/arm/bcm_vk/valkyrie/soc.h
 +++ b/soc/arm/bcm_vk/valkyrie/soc.h
 @@ -11,7 +11,6 @@
@@ -16315,7 +16057,7 @@ index fa254cbe0b..1a076a225f 100644
  /* Interrupt Number Definition */
  typedef enum IRQn {
 diff --git a/soc/arm/bcm_vk/viper/soc.h b/soc/arm/bcm_vk/viper/soc.h
-index 691ff182d2..8339e903f7 100644
+index 691ff182d..8339e903f 100644
 --- a/soc/arm/bcm_vk/viper/soc.h
 +++ b/soc/arm/bcm_vk/viper/soc.h
 @@ -12,7 +12,6 @@
@@ -16327,7 +16069,7 @@ index 691ff182d2..8339e903f7 100644
  /* Interrupt Number Definition */
  typedef enum IRQn {
 diff --git a/soc/arm/cypress/psoc6/soc.h b/soc/arm/cypress/psoc6/soc.h
-index eabed08127..c332d30c52 100644
+index eabed0812..c332d30c5 100644
 --- a/soc/arm/cypress/psoc6/soc.h
 +++ b/soc/arm/cypress/psoc6/soc.h
 @@ -19,8 +19,6 @@
@@ -16340,7 +16082,7 @@ index eabed08127..c332d30c52 100644
  #include <cy_device_headers.h>
  
 diff --git a/soc/arm/infineon_xmc/4xxx/soc.h b/soc/arm/infineon_xmc/4xxx/soc.h
-index 791821283a..1afb6c588a 100644
+index 791821283..1afb6c588 100644
 --- a/soc/arm/infineon_xmc/4xxx/soc.h
 +++ b/soc/arm/infineon_xmc/4xxx/soc.h
 @@ -6,7 +6,5 @@
@@ -16352,7 +16094,7 @@ index 791821283a..1afb6c588a 100644
  #include <system_XMC4500.h>
  #include <XMC4500.h>
 diff --git a/soc/arm/nuvoton_npcx/npcx7/soc.h b/soc/arm/nuvoton_npcx/npcx7/soc.h
-index a9b6b9ed1e..9c293e0575 100644
+index a9b6b9ed1..9c293e057 100644
 --- a/soc/arm/nuvoton_npcx/npcx7/soc.h
 +++ b/soc/arm/nuvoton_npcx/npcx7/soc.h
 @@ -11,8 +11,6 @@
@@ -16365,7 +16107,7 @@ index a9b6b9ed1e..9c293e0575 100644
  #include <reg/reg_access.h>
  #include <reg/reg_def.h>
 diff --git a/soc/arm/nuvoton_npcx/npcx9/soc.h b/soc/arm/nuvoton_npcx/npcx9/soc.h
-index 6c43c2cb46..a1769e11a0 100644
+index 6c43c2cb4..a1769e11a 100644
 --- a/soc/arm/nuvoton_npcx/npcx9/soc.h
 +++ b/soc/arm/nuvoton_npcx/npcx9/soc.h
 @@ -11,8 +11,6 @@
@@ -16378,7 +16120,7 @@ index 6c43c2cb46..a1769e11a0 100644
  #include <reg/reg_access.h>
  #include <reg/reg_def.h>
 diff --git a/soc/arm/nuvoton_numicro/m48x/soc.h b/soc/arm/nuvoton_numicro/m48x/soc.h
-index 36db0ea8fa..a33c8b3dd6 100644
+index 36db0ea8f..a33c8b3dd 100644
 --- a/soc/arm/nuvoton_numicro/m48x/soc.h
 +++ b/soc/arm/nuvoton_numicro/m48x/soc.h
 @@ -9,7 +9,6 @@
@@ -16390,7 +16132,7 @@ index 36db0ea8fa..a33c8b3dd6 100644
  
  #endif /* ZEPHYR_SOC_ARM_NUVOTON_M48X_SOC_H_*/
 diff --git a/soc/arm/nxp_kinetis/k6x/soc.h b/soc/arm/nxp_kinetis/k6x/soc.h
-index 3fa36de72d..0e3b1a9013 100644
+index 3fa36de72..0e3b1a901 100644
 --- a/soc/arm/nxp_kinetis/k6x/soc.h
 +++ b/soc/arm/nxp_kinetis/k6x/soc.h
 @@ -25,8 +25,6 @@
@@ -16403,7 +16145,7 @@ index 3fa36de72d..0e3b1a9013 100644
  #endif /* !_ASMLANGUAGE */
  
 diff --git a/soc/arm/nxp_kinetis/k8x/soc.h b/soc/arm/nxp_kinetis/k8x/soc.h
-index 518d6676ce..924c8ca8a9 100644
+index 518d6676c..924c8ca8a 100644
 --- a/soc/arm/nxp_kinetis/k8x/soc.h
 +++ b/soc/arm/nxp_kinetis/k8x/soc.h
 @@ -17,8 +17,6 @@ extern "C" {
@@ -16416,7 +16158,7 @@ index 518d6676ce..924c8ca8a9 100644
  #endif /* !_ASMLANGUAGE */
  
 diff --git a/soc/arm/nxp_kinetis/ke1xf/soc.h b/soc/arm/nxp_kinetis/ke1xf/soc.h
-index adb185cc52..46e052c674 100644
+index adb185cc5..46e052c67 100644
 --- a/soc/arm/nxp_kinetis/ke1xf/soc.h
 +++ b/soc/arm/nxp_kinetis/ke1xf/soc.h
 @@ -13,8 +13,6 @@
@@ -16429,7 +16171,7 @@ index adb185cc52..46e052c674 100644
  #endif /* !_ASMLANGUAGE */
  
 diff --git a/soc/arm/nxp_kinetis/kl2x/soc.h b/soc/arm/nxp_kinetis/kl2x/soc.h
-index 569c9014c2..0b6a15293d 100644
+index 569c9014c..0b6a15293 100644
 --- a/soc/arm/nxp_kinetis/kl2x/soc.h
 +++ b/soc/arm/nxp_kinetis/kl2x/soc.h
 @@ -15,8 +15,6 @@
@@ -16442,7 +16184,7 @@ index 569c9014c2..0b6a15293d 100644
  #endif /* !_ASMLANGUAGE */
  
 diff --git a/soc/arm/nxp_kinetis/kv5x/soc.h b/soc/arm/nxp_kinetis/kv5x/soc.h
-index 518d6676ce..924c8ca8a9 100644
+index 518d6676c..924c8ca8a 100644
 --- a/soc/arm/nxp_kinetis/kv5x/soc.h
 +++ b/soc/arm/nxp_kinetis/kv5x/soc.h
 @@ -17,8 +17,6 @@ extern "C" {
@@ -16455,7 +16197,7 @@ index 518d6676ce..924c8ca8a9 100644
  #endif /* !_ASMLANGUAGE */
  
 diff --git a/soc/arm/nxp_kinetis/kwx/soc.h b/soc/arm/nxp_kinetis/kwx/soc.h
-index 959fcaee78..e121b68a7c 100644
+index 959fcaee7..e121b68a7 100644
 --- a/soc/arm/nxp_kinetis/kwx/soc.h
 +++ b/soc/arm/nxp_kinetis/kwx/soc.h
 @@ -26,8 +26,6 @@
@@ -16468,7 +16210,7 @@ index 959fcaee78..e121b68a7c 100644
  #endif /* !_ASMLANGUAGE */
  
 diff --git a/soc/arm/nxp_lpc/lpc11u6x/soc.h b/soc/arm/nxp_lpc/lpc11u6x/soc.h
-index f71776ef3d..7001e76ae9 100644
+index f71776ef3..7001e76ae 100644
 --- a/soc/arm/nxp_lpc/lpc11u6x/soc.h
 +++ b/soc/arm/nxp_lpc/lpc11u6x/soc.h
 @@ -18,8 +18,6 @@
@@ -16481,7 +16223,7 @@ index f71776ef3d..7001e76ae9 100644
  #endif /* !_ASMLANGUAGE */
  
 diff --git a/soc/arm/nxp_lpc/lpc54xxx/soc.h b/soc/arm/nxp_lpc/lpc54xxx/soc.h
-index 8e8e7d9571..309287ede5 100644
+index 8e8e7d957..309287ede 100644
 --- a/soc/arm/nxp_lpc/lpc54xxx/soc.h
 +++ b/soc/arm/nxp_lpc/lpc54xxx/soc.h
 @@ -19,8 +19,6 @@
@@ -16494,7 +16236,7 @@ index 8e8e7d9571..309287ede5 100644
  #endif /* !_ASMLANGUAGE */
  
 diff --git a/soc/arm/nxp_lpc/lpc55xxx/soc.h b/soc/arm/nxp_lpc/lpc55xxx/soc.h
-index c17e8a1063..c85945966d 100644
+index c17e8a106..c85945966 100644
 --- a/soc/arm/nxp_lpc/lpc55xxx/soc.h
 +++ b/soc/arm/nxp_lpc/lpc55xxx/soc.h
 @@ -19,8 +19,6 @@
@@ -16507,7 +16249,7 @@ index c17e8a1063..c85945966d 100644
  #endif /* !_ASMLANGUAGE */
  
 diff --git a/soc/arm/quicklogic_eos_s3/soc.h b/soc/arm/quicklogic_eos_s3/soc.h
-index 5bb05c4acb..dcebcb6bab 100644
+index 5bb05c4ac..dcebcb6ba 100644
 --- a/soc/arm/quicklogic_eos_s3/soc.h
 +++ b/soc/arm/quicklogic_eos_s3/soc.h
 @@ -9,7 +9,6 @@
@@ -16519,7 +16261,7 @@ index 5bb05c4acb..dcebcb6bab 100644
  /* Available frequencies */
  #define HSOSC_1MHZ	1024000
 diff --git a/soc/arm/silabs_exx32/efm32gg11b/soc.h b/soc/arm/silabs_exx32/efm32gg11b/soc.h
-index 36744e68f3..3de7ede03c 100644
+index 36744e68f..3de7ede03 100644
 --- a/soc/arm/silabs_exx32/efm32gg11b/soc.h
 +++ b/soc/arm/silabs_exx32/efm32gg11b/soc.h
 @@ -25,8 +25,6 @@ extern "C" {
@@ -16532,7 +16274,7 @@ index 36744e68f3..3de7ede03c 100644
  #include "soc_pinmap.h"
  #include "../common/soc_gpio.h"
 diff --git a/soc/arm/silabs_exx32/efm32jg12b/soc.h b/soc/arm/silabs_exx32/efm32jg12b/soc.h
-index e1d9030ffe..d66a008575 100644
+index e1d9030ff..d66a00857 100644
 --- a/soc/arm/silabs_exx32/efm32jg12b/soc.h
 +++ b/soc/arm/silabs_exx32/efm32jg12b/soc.h
 @@ -20,8 +20,6 @@
@@ -16545,7 +16287,7 @@ index e1d9030ffe..d66a008575 100644
  #include "soc_pinmap.h"
  #include "../common/soc_gpio.h"
 diff --git a/soc/arm/silabs_exx32/efm32pg12b/soc.h b/soc/arm/silabs_exx32/efm32pg12b/soc.h
-index dc568a38fa..4d30b3d943 100644
+index dc568a38f..4d30b3d94 100644
 --- a/soc/arm/silabs_exx32/efm32pg12b/soc.h
 +++ b/soc/arm/silabs_exx32/efm32pg12b/soc.h
 @@ -20,8 +20,6 @@
@@ -16558,7 +16300,7 @@ index dc568a38fa..4d30b3d943 100644
  #include "soc_pinmap.h"
  #include "../common/soc_gpio.h"
 diff --git a/soc/arm/silabs_exx32/efm32pg1b/soc.h b/soc/arm/silabs_exx32/efm32pg1b/soc.h
-index e27c401114..81f923f05c 100644
+index e27c40111..81f923f05 100644
 --- a/soc/arm/silabs_exx32/efm32pg1b/soc.h
 +++ b/soc/arm/silabs_exx32/efm32pg1b/soc.h
 @@ -20,8 +20,6 @@
@@ -16571,7 +16313,7 @@ index e27c401114..81f923f05c 100644
  #include "soc_pinmap.h"
  #include "../common/soc_gpio.h"
 diff --git a/soc/arm/silabs_exx32/efm32wg/soc.h b/soc/arm/silabs_exx32/efm32wg/soc.h
-index 4617ed91d5..2c9cbeb919 100644
+index 4617ed91d..2c9cbeb91 100644
 --- a/soc/arm/silabs_exx32/efm32wg/soc.h
 +++ b/soc/arm/silabs_exx32/efm32wg/soc.h
 @@ -20,8 +20,6 @@
@@ -16584,7 +16326,7 @@ index 4617ed91d5..2c9cbeb919 100644
  #include "soc_pinmap.h"
  #include "../common/soc_gpio.h"
 diff --git a/soc/arm/silabs_exx32/efr32bg13p/soc.h b/soc/arm/silabs_exx32/efr32bg13p/soc.h
-index d9736f521b..e04f1ea865 100644
+index d9736f521..e04f1ea86 100644
 --- a/soc/arm/silabs_exx32/efr32bg13p/soc.h
 +++ b/soc/arm/silabs_exx32/efr32bg13p/soc.h
 @@ -22,8 +22,6 @@
@@ -16597,7 +16339,7 @@ index d9736f521b..e04f1ea865 100644
  #endif /* !_ASMLANGUAGE */
  
 diff --git a/soc/arm/silabs_exx32/efr32fg13p/soc.h b/soc/arm/silabs_exx32/efr32fg13p/soc.h
-index 770ef4ca77..21b4c924eb 100644
+index 770ef4ca7..21b4c924e 100644
 --- a/soc/arm/silabs_exx32/efr32fg13p/soc.h
 +++ b/soc/arm/silabs_exx32/efr32fg13p/soc.h
 @@ -20,8 +20,6 @@
@@ -16610,7 +16352,7 @@ index 770ef4ca77..21b4c924eb 100644
  #include "soc_pinmap.h"
  #include "../common/soc_gpio.h"
 diff --git a/soc/arm/silabs_exx32/efr32fg1p/soc.h b/soc/arm/silabs_exx32/efr32fg1p/soc.h
-index beefd630a3..944f2e8389 100644
+index beefd630a..944f2e838 100644
 --- a/soc/arm/silabs_exx32/efr32fg1p/soc.h
 +++ b/soc/arm/silabs_exx32/efr32fg1p/soc.h
 @@ -20,8 +20,6 @@
@@ -16623,7 +16365,7 @@ index beefd630a3..944f2e8389 100644
  #include "soc_pinmap.h"
  #include "../common/soc_gpio.h"
 diff --git a/soc/arm/silabs_exx32/efr32mg12p/soc.h b/soc/arm/silabs_exx32/efr32mg12p/soc.h
-index 13d2849249..02a07333be 100644
+index 13d284924..02a07333b 100644
 --- a/soc/arm/silabs_exx32/efr32mg12p/soc.h
 +++ b/soc/arm/silabs_exx32/efr32mg12p/soc.h
 @@ -19,8 +19,6 @@
@@ -16636,7 +16378,7 @@ index 13d2849249..02a07333be 100644
  #include "soc_pinmap.h"
  #include "../common/soc_gpio.h"
 diff --git a/soc/arm/silabs_exx32/efr32mg21/soc.h b/soc/arm/silabs_exx32/efr32mg21/soc.h
-index 2afcd89475..16d5703dbf 100644
+index 2afcd8947..16d5703db 100644
 --- a/soc/arm/silabs_exx32/efr32mg21/soc.h
 +++ b/soc/arm/silabs_exx32/efr32mg21/soc.h
 @@ -22,8 +22,6 @@
@@ -16649,7 +16391,7 @@ index 2afcd89475..16d5703dbf 100644
  #endif  /* !_ASMLANGUAGE */
  
 diff --git a/soc/arm64/arm/fvp_aemv8r/soc.h b/soc/arm64/arm/fvp_aemv8r/soc.h
-index c2ac0f5223..a78350bd0d 100644
+index c2ac0f522..a78350bd0 100644
 --- a/soc/arm64/arm/fvp_aemv8r/soc.h
 +++ b/soc/arm64/arm/fvp_aemv8r/soc.h
 @@ -6,6 +6,5 @@
@@ -16660,7 +16402,7 @@ index c2ac0f5223..a78350bd0d 100644
  
  #endif /* _SOC_H_ */
 diff --git a/soc/arm64/nxp_layerscape/ls1046a/soc.h b/soc/arm64/nxp_layerscape/ls1046a/soc.h
-index 888dc21aa2..e39112c1bc 100644
+index 888dc21aa..e39112c1b 100644
 --- a/soc/arm64/nxp_layerscape/ls1046a/soc.h
 +++ b/soc/arm64/nxp_layerscape/ls1046a/soc.h
 @@ -11,7 +11,6 @@
@@ -16672,7 +16414,7 @@ index 888dc21aa2..e39112c1bc 100644
  
  #define UART_REG_ADDR_INTERVAL 1
 diff --git a/soc/riscv/riscv-ite/it8xxx2/soc.h b/soc/riscv/riscv-ite/it8xxx2/soc.h
-index 6d85eeeb65..04cbfdcaf4 100644
+index 6d85eeeb6..04cbfdcaf 100644
 --- a/soc/riscv/riscv-ite/it8xxx2/soc.h
 +++ b/soc/riscv/riscv-ite/it8xxx2/soc.h
 @@ -7,7 +7,6 @@
@@ -16684,7 +16426,7 @@ index 6d85eeeb65..04cbfdcaf4 100644
  #define UART_REG_ADDR_INTERVAL 1
  
 diff --git a/soc/riscv/riscv-privilege/andes_v5/ae350/soc.h b/soc/riscv/riscv-privilege/andes_v5/ae350/soc.h
-index f938ca38b1..fee3300466 100644
+index f938ca38b..fee330046 100644
 --- a/soc/riscv/riscv-privilege/andes_v5/ae350/soc.h
 +++ b/soc/riscv/riscv-privilege/andes_v5/ae350/soc.h
 @@ -12,7 +12,6 @@
@@ -16696,7 +16438,7 @@ index f938ca38b1..fee3300466 100644
  /* Machine timer memory-mapped registers */
  #define RISCV_MTIME_BASE             0xE6000000
 diff --git a/soc/riscv/riscv-privilege/miv/soc.h b/soc/riscv/riscv-privilege/miv/soc.h
-index 0e2bf67c29..4391e428fa 100644
+index 0e2bf67c2..4391e428f 100644
 --- a/soc/riscv/riscv-privilege/miv/soc.h
 +++ b/soc/riscv/riscv-privilege/miv/soc.h
 @@ -5,7 +5,6 @@
@@ -16708,7 +16450,7 @@ index 0e2bf67c29..4391e428fa 100644
  /* GPIO Interrupts */
  #define MIV_GPIO_0_IRQ           (0)
 diff --git a/soc/riscv/riscv-privilege/sifive-freedom/soc.h b/soc/riscv/riscv-privilege/sifive-freedom/soc.h
-index 56cbbb19c1..f67b9e85b0 100644
+index 56cbbb19c..f67b9e85b 100644
 --- a/soc/riscv/riscv-privilege/sifive-freedom/soc.h
 +++ b/soc/riscv/riscv-privilege/sifive-freedom/soc.h
 @@ -12,7 +12,6 @@
@@ -16720,7 +16462,7 @@ index 56cbbb19c1..f67b9e85b0 100644
  #if defined(CONFIG_SOC_RISCV_SIFIVE_FREEDOM)
  
 diff --git a/soc/riscv/riscv-privilege/starfive_jh71xx/soc.h b/soc/riscv/riscv-privilege/starfive_jh71xx/soc.h
-index 16d861cbc6..0491bdaf41 100644
+index 16d861cbc..0491bdaf4 100644
 --- a/soc/riscv/riscv-privilege/starfive_jh71xx/soc.h
 +++ b/soc/riscv/riscv-privilege/starfive_jh71xx/soc.h
 @@ -8,7 +8,6 @@
@@ -16732,7 +16474,7 @@ index 16d861cbc6..0491bdaf41 100644
  #define RISCV_MTIME_BASE 0x0200BFF8
  #define RISCV_MTIMECMP_BASE 0x02004000
 diff --git a/soc/riscv/riscv-privilege/telink_b91/soc.h b/soc/riscv/riscv-privilege/telink_b91/soc.h
-index 2f932c09d4..97c0cf56b2 100644
+index 2f932c09d..97c0cf56b 100644
 --- a/soc/riscv/riscv-privilege/telink_b91/soc.h
 +++ b/soc/riscv/riscv-privilege/telink_b91/soc.h
 @@ -8,7 +8,6 @@
@@ -16744,7 +16486,7 @@ index 2f932c09d4..97c0cf56b2 100644
  /* Machine timer memory-mapped registers */
  #define RISCV_MTIME_BASE             0xE6000000
 diff --git a/soc/riscv/riscv-privilege/virt/soc.h b/soc/riscv/riscv-privilege/virt/soc.h
-index d31f4376c2..4802240782 100644
+index d31f4376c..480224078 100644
 --- a/soc/riscv/riscv-privilege/virt/soc.h
 +++ b/soc/riscv/riscv-privilege/virt/soc.h
 @@ -8,7 +8,6 @@
@@ -16756,14 +16498,13 @@ index d31f4376c2..4802240782 100644
  #define SIFIVE_SYSCON_TEST           0x00100000
  #define RISCV_MTIME_BASE             0x0200BFF8
 -- 
-2.17.1
+2.25.1
 
 
-From af3cb61f2f8aca0dac4e5d39066be432babdadd4 Mon Sep 17 00:00:00 2001
+From 40d491e814d856473ea3aa2d92edb625f59407ca Mon Sep 17 00:00:00 2001
 From: Jay Vasanth <jay.vasanth@microchip.com>
 Date: Thu, 20 Jan 2022 14:51:01 -0500
-Subject: [PATCH 049/112] [BACPORTED][MODIFIED] drivers: pinctrl: Microchip
- MEC172x pinctrl driver
+Subject: [PATCH 048/111] drivers: pinctrl: Microchip MEC172x pinctrl driver
 
 Add core files for Microchip MEC172x pinctrl driver
 
@@ -16789,7 +16530,7 @@ Signed-off-by: Jay Vasanth <jay.vasanth@microchip.com>
  create mode 100644 soc/arm/microchip_mec/common/soc_dt.h
 
 diff --git a/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906_defconfig b/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906_defconfig
-index 1d662ffe26..7487c8f9c2 100644
+index 1d662ffe2..7487c8f9c 100644
 --- a/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906_defconfig
 +++ b/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906_defconfig
 @@ -12,6 +12,7 @@ CONFIG_RTOS_TIMER=y
@@ -16801,7 +16542,7 @@ index 1d662ffe26..7487c8f9c2 100644
  CONFIG_CONSOLE=y
  CONFIG_UART_CONSOLE=y
 diff --git a/drivers/pinctrl/CMakeLists.txt b/drivers/pinctrl/CMakeLists.txt
-index cd3eca95d8..3612b13904 100644
+index cd3eca95d..3612b1390 100644
 --- a/drivers/pinctrl/CMakeLists.txt
 +++ b/drivers/pinctrl/CMakeLists.txt
 @@ -3,3 +3,4 @@
@@ -16810,7 +16551,7 @@ index cd3eca95d8..3612b13904 100644
  zephyr_library_sources(common.c)
 +zephyr_library_sources_ifdef(CONFIG_PINCTRL_MCHP_XEC pinctrl_mchp_xec.c)
 diff --git a/drivers/pinctrl/Kconfig b/drivers/pinctrl/Kconfig
-index 7e1a67175b..1c83e07f45 100644
+index 7e1a67175..1c83e07f4 100644
 --- a/drivers/pinctrl/Kconfig
 +++ b/drivers/pinctrl/Kconfig
 @@ -30,3 +30,5 @@ config PINCTRL_DYNAMIC
@@ -16821,7 +16562,7 @@ index 7e1a67175b..1c83e07f45 100644
 +source "drivers/pinctrl/Kconfig.xec"
 diff --git a/drivers/pinctrl/Kconfig.xec b/drivers/pinctrl/Kconfig.xec
 new file mode 100644
-index 0000000000..fdcdf627cb
+index 000000000..fdcdf627c
 --- /dev/null
 +++ b/drivers/pinctrl/Kconfig.xec
 @@ -0,0 +1,11 @@
@@ -16838,7 +16579,7 @@ index 0000000000..fdcdf627cb
 +	  Enable pin controller driver for Microchip XEC MCUs
 diff --git a/drivers/pinctrl/pinctrl_mchp_xec.c b/drivers/pinctrl/pinctrl_mchp_xec.c
 new file mode 100644
-index 0000000000..05fece9528
+index 000000000..05fece952
 --- /dev/null
 +++ b/drivers/pinctrl/pinctrl_mchp_xec.c
 @@ -0,0 +1,150 @@
@@ -16994,7 +16735,7 @@ index 0000000000..05fece9528
 +}
 diff --git a/include/dt-bindings/pinctrl/mchp-xec-pinctrl.h b/include/dt-bindings/pinctrl/mchp-xec-pinctrl.h
 new file mode 100644
-index 0000000000..08725a4d8e
+index 000000000..08725a4d8
 --- /dev/null
 +++ b/include/dt-bindings/pinctrl/mchp-xec-pinctrl.h
 @@ -0,0 +1,81 @@
@@ -17080,7 +16821,7 @@ index 0000000000..08725a4d8e
 +
 +#endif	/* ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_MCHP_XEC_PINCTRL_H_ */
 diff --git a/soc/arm/microchip_mec/CMakeLists.txt b/soc/arm/microchip_mec/CMakeLists.txt
-index 226f3bd626..ae6495b7b0 100644
+index 226f3bd62..ae6495b7b 100644
 --- a/soc/arm/microchip_mec/CMakeLists.txt
 +++ b/soc/arm/microchip_mec/CMakeLists.txt
 @@ -1,3 +1,4 @@
@@ -17090,7 +16831,7 @@ index 226f3bd626..ae6495b7b0 100644
 +add_subdirectory(common)
 diff --git a/soc/arm/microchip_mec/common/CMakeLists.txt b/soc/arm/microchip_mec/common/CMakeLists.txt
 new file mode 100644
-index 0000000000..7b4e1e885b
+index 000000000..7b4e1e885
 --- /dev/null
 +++ b/soc/arm/microchip_mec/common/CMakeLists.txt
 @@ -0,0 +1,3 @@
@@ -17099,7 +16840,7 @@ index 0000000000..7b4e1e885b
 +zephyr_include_directories_ifdef(CONFIG_SOC_SERIES_MEC172X .)
 diff --git a/soc/arm/microchip_mec/common/pinctrl_soc.h b/soc/arm/microchip_mec/common/pinctrl_soc.h
 new file mode 100644
-index 0000000000..23c55a4f53
+index 000000000..23c55a4f5
 --- /dev/null
 +++ b/soc/arm/microchip_mec/common/pinctrl_soc.h
 @@ -0,0 +1,101 @@
@@ -17206,7 +16947,7 @@ index 0000000000..23c55a4f53
 +#endif /* ZEPHYR_SOC_ARM_MICROCHIP_XEC_COMMON_PINCTRL_SOC_H_ */
 diff --git a/soc/arm/microchip_mec/common/soc_dt.h b/soc/arm/microchip_mec/common/soc_dt.h
 new file mode 100644
-index 0000000000..86354aa8fb
+index 000000000..86354aa8f
 --- /dev/null
 +++ b/soc/arm/microchip_mec/common/soc_dt.h
 @@ -0,0 +1,25 @@
@@ -17236,7 +16977,7 @@ index 0000000000..86354aa8fb
 +
 +#endif /* _MICROCHIP_XEC_SOC_DT_H_ */
 diff --git a/soc/arm/microchip_mec/mec172x/soc.h b/soc/arm/microchip_mec/mec172x/soc.h
-index c9451b77d6..d33ae1d56f 100644
+index c9451b77d..d33ae1d56 100644
 --- a/soc/arm/microchip_mec/mec172x/soc.h
 +++ b/soc/arm/microchip_mec/mec172x/soc.h
 @@ -276,6 +276,7 @@ typedef enum {
@@ -17248,13 +16989,13 @@ index c9451b77d6..d33ae1d56f 100644
  #include "../common/soc_pcr.h"
  #include "../common/soc_pins.h"
 -- 
-2.17.1
+2.25.1
 
 
-From 34332097743335262e1f8394701fba5c6cb633ae Mon Sep 17 00:00:00 2001
+From 2ff9d447ceb25a42333cb1f6cb7555d0799061ec Mon Sep 17 00:00:00 2001
 From: Jay Vasanth <jay.vasanth@microchip.com>
 Date: Thu, 20 Jan 2022 15:45:56 -0500
-Subject: [PATCH 050/112] [BACPORTED] dts: Update MEC172x pinctrl dts
+Subject: [PATCH 049/111] dts: Update MEC172x pinctrl dts
 
 Update dtsi and dts bindings for pinctrl driver
 
@@ -17269,7 +17010,7 @@ Signed-off-by: Jay Vasanth <jay.vasanth@microchip.com>
  create mode 100644 dts/bindings/pinctrl/microchip,xec-pinctrl.yaml
 
 diff --git a/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts b/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts
-index eabaab748b..9108c69f5d 100644
+index eabaab748..9108c69f5 100644
 --- a/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts
 +++ b/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts
 @@ -7,6 +7,7 @@
@@ -17390,7 +17131,7 @@ index eabaab748b..9108c69f5d 100644
  &kscan0 {
 diff --git a/dts/arm/microchip/mec172x/mec172xnsz-pinctrl.dtsi b/dts/arm/microchip/mec172x/mec172xnsz-pinctrl.dtsi
 new file mode 100644
-index 0000000000..36dabfc598
+index 000000000..36dabfc59
 --- /dev/null
 +++ b/dts/arm/microchip/mec172x/mec172xnsz-pinctrl.dtsi
 @@ -0,0 +1,1057 @@
@@ -18452,7 +18193,7 @@ index 0000000000..36dabfc598
 +
 +};
 diff --git a/dts/arm/microchip/mec172xnsz.dtsi b/dts/arm/microchip/mec172xnsz.dtsi
-index 4cf09720c0..e36f964c1f 100644
+index 4cf09720c..e36f964c1 100644
 --- a/dts/arm/microchip/mec172xnsz.dtsi
 +++ b/dts/arm/microchip/mec172xnsz.dtsi
 @@ -287,71 +287,78 @@
@@ -18601,7 +18342,7 @@ index 4cf09720c0..e36f964c1f 100644
  			compatible = "microchip,xec-watchdog";
 diff --git a/dts/bindings/pinctrl/microchip,xec-pinctrl.yaml b/dts/bindings/pinctrl/microchip,xec-pinctrl.yaml
 new file mode 100644
-index 0000000000..c67f3b380d
+index 000000000..c67f3b380
 --- /dev/null
 +++ b/dts/bindings/pinctrl/microchip,xec-pinctrl.yaml
 @@ -0,0 +1,121 @@
@@ -18727,14 +18468,13 @@ index 0000000000..c67f3b380d
 +            are 4, 8, 16, or 24 mA. Please refer to the data sheet for each
 +            pin's PIO type and default drive strength.
 -- 
-2.17.1
+2.25.1
 
 
-From 81efc7abe1980d1aae84ea707a170dbad69ef867 Mon Sep 17 00:00:00 2001
+From fd914448aeadbdb0754dfc6f09821e43e1fa890d Mon Sep 17 00:00:00 2001
 From: Jay Vasanth <jay.vasanth@microchip.com>
 Date: Thu, 20 Jan 2022 16:37:05 -0500
-Subject: [PATCH 051/112] [BACPORTED] gpio: MEC172x: update gpio module for
- pinctrl
+Subject: [PATCH 050/111] gpio: MEC172x: update gpio module for pinctrl
 
 Changes to gpio module to support pinctrl
 
@@ -18745,7 +18485,7 @@ Signed-off-by: Jay Vasanth <jay.vasanth@microchip.com>
  2 files changed, 31 insertions(+), 15 deletions(-)
 
 diff --git a/drivers/gpio/gpio_mchp_xec_v2.c b/drivers/gpio/gpio_mchp_xec_v2.c
-index 3051157031..a59a78aafc 100644
+index 305115703..a59a78aaf 100644
 --- a/drivers/gpio/gpio_mchp_xec_v2.c
 +++ b/drivers/gpio/gpio_mchp_xec_v2.c
 @@ -9,6 +9,7 @@
@@ -18765,7 +18505,7 @@ index 3051157031..a59a78aafc 100644
  	.pin_configure = gpio_xec_configure,
  	.port_get_raw = gpio_xec_port_get_raw,
 diff --git a/soc/arm/microchip_mec/mec172x/reg/mec172x_gpio.h b/soc/arm/microchip_mec/mec172x/reg/mec172x_gpio.h
-index 5c45004356..8cb981fcad 100644
+index 5c4500435..8cb981fca 100644
 --- a/soc/arm/microchip_mec/mec172x/reg/mec172x_gpio.h
 +++ b/soc/arm/microchip_mec/mec172x/reg/mec172x_gpio.h
 @@ -21,15 +21,15 @@
@@ -18875,14 +18615,13 @@ index 5c45004356..8cb981fcad 100644
  	volatile uint32_t CTRL2_0121;
  	volatile uint32_t CTRL2_0122;
 -- 
-2.17.1
+2.25.1
 
 
-From 6fb8de7f5e3a2dd12b06b94042881ebbde96b56f Mon Sep 17 00:00:00 2001
+From 68b8733189db2851b77fdc91634ddf8378d08fde Mon Sep 17 00:00:00 2001
 From: Jay Vasanth <jay.vasanth@microchip.com>
 Date: Thu, 20 Jan 2022 17:24:12 -0500
-Subject: [PATCH 052/112] [BACPORTED][MODIFIED] i2c: update MEC172x i2c module
- for pinctrl
+Subject: [PATCH 051/111] i2c: update MEC172x i2c module for pinctrl
 
 Changes to i2c module to support pinctrl
 
@@ -18899,7 +18638,7 @@ Signed-off-by: Jay Vasanth <jay.vasanth@microchip.com>
  create mode 100644 soc/arm/microchip_mec/common/soc_i2c.h
 
 diff --git a/drivers/i2c/i2c_mchp_xec_v2.c b/drivers/i2c/i2c_mchp_xec_v2.c
-index f38bbd0370..cc873ce32a 100644
+index f38bbd037..cc873ce32 100644
 --- a/drivers/i2c/i2c_mchp_xec_v2.c
 +++ b/drivers/i2c/i2c_mchp_xec_v2.c
 @@ -14,7 +14,7 @@
@@ -19099,7 +18838,7 @@ index f38bbd0370..cc873ce32a 100644
  			    DT_INST_IRQ(n, priority),			\
  			    i2c_xec_bus_isr,				\
 diff --git a/dts/bindings/i2c/microchip,xec-i2c-v2.yaml b/dts/bindings/i2c/microchip,xec-i2c-v2.yaml
-index 1934fe2dbb..32b30fcc05 100644
+index 1934fe2db..32b30fcc0 100644
 --- a/dts/bindings/i2c/microchip,xec-i2c-v2.yaml
 +++ b/dts/bindings/i2c/microchip,xec-i2c-v2.yaml
 @@ -5,7 +5,7 @@ description: Microchip I2C/SMB V2 controller
@@ -19125,7 +18864,7 @@ index 1934fe2dbb..32b30fcc05 100644
        type: int
        const: 2
 diff --git a/soc/arm/microchip_mec/common/CMakeLists.txt b/soc/arm/microchip_mec/common/CMakeLists.txt
-index 7b4e1e885b..d854656c9f 100644
+index 7b4e1e885..d854656c9 100644
 --- a/soc/arm/microchip_mec/common/CMakeLists.txt
 +++ b/soc/arm/microchip_mec/common/CMakeLists.txt
 @@ -1,3 +1,6 @@
@@ -19137,7 +18876,7 @@ index 7b4e1e885b..d854656c9f 100644
 +)
 diff --git a/soc/arm/microchip_mec/common/soc_i2c.c b/soc/arm/microchip_mec/common/soc_i2c.c
 new file mode 100644
-index 0000000000..23a63fbdfa
+index 000000000..23a63fbdf
 --- /dev/null
 +++ b/soc/arm/microchip_mec/common/soc_i2c.c
 @@ -0,0 +1,109 @@
@@ -19252,7 +18991,7 @@ index 0000000000..23a63fbdfa
 +}
 diff --git a/soc/arm/microchip_mec/common/soc_i2c.h b/soc/arm/microchip_mec/common/soc_i2c.h
 new file mode 100644
-index 0000000000..2398b1421b
+index 000000000..2398b1421
 --- /dev/null
 +++ b/soc/arm/microchip_mec/common/soc_i2c.h
 @@ -0,0 +1,52 @@
@@ -19309,7 +19048,7 @@ index 0000000000..2398b1421b
 +
 +#endif /* _MICROCHIP_MEC_SOC_I2C_H_ */
 diff --git a/soc/arm/microchip_mec/mec172x/soc.h b/soc/arm/microchip_mec/mec172x/soc.h
-index d33ae1d56f..092db77e3b 100644
+index d33ae1d56..092db77e3 100644
 --- a/soc/arm/microchip_mec/mec172x/soc.h
 +++ b/soc/arm/microchip_mec/mec172x/soc.h
 @@ -283,6 +283,7 @@ typedef enum {
@@ -19321,14 +19060,13 @@ index d33ae1d56f..092db77e3b 100644
  #endif
  
 -- 
-2.17.1
+2.25.1
 
 
-From a7b61e892e6e3c48156a38d215023f2976d3f686 Mon Sep 17 00:00:00 2001
+From ff37a612e1f78739fff8d9b8f14e94209513289b Mon Sep 17 00:00:00 2001
 From: Jay Vasanth <jay.vasanth@microchip.com>
 Date: Fri, 21 Jan 2022 12:15:27 -0500
-Subject: [PATCH 053/112] [BACPORTED] espi: updated MEC172x espi module for
- pinctrl
+Subject: [PATCH 052/111] espi: updated MEC172x espi module for pinctrl
 
 Changes to espi module to support pinctrl
 
@@ -19340,7 +19078,7 @@ Signed-off-by: Jay Vasanth <jay.vasanth@microchip.com>
  3 files changed, 24 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/espi/espi_mchp_xec_v2.c b/drivers/espi/espi_mchp_xec_v2.c
-index 1faa343356..9dc37d35ff 100644
+index 1faa34335..9dc37d35f 100644
 --- a/drivers/espi/espi_mchp_xec_v2.c
 +++ b/drivers/espi/espi_mchp_xec_v2.c
 @@ -1207,13 +1207,17 @@ static const struct espi_xec_irq_info espi_xec_irq_info_0[] = {
@@ -19385,7 +19123,7 @@ index 1faa343356..9dc37d35ff 100644
  #ifdef ESPI_XEC_V2_DEBUG
  	data->espi_rst_count = 0;
 diff --git a/drivers/espi/espi_mchp_xec_v2.h b/drivers/espi/espi_mchp_xec_v2.h
-index d984c39a50..c10e4bb8c6 100644
+index d984c39a5..c10e4bb8c 100644
 --- a/drivers/espi/espi_mchp_xec_v2.h
 +++ b/drivers/espi/espi_mchp_xec_v2.h
 @@ -10,6 +10,7 @@
@@ -19409,7 +19147,7 @@ index d984c39a50..c10e4bb8c6 100644
  
  #define ESPI_XEC_CONFIG(dev)						\
 diff --git a/dts/bindings/espi/microchip,xec-espi-v2.yaml b/dts/bindings/espi/microchip,xec-espi-v2.yaml
-index 563dc93a52..3d919577e7 100644
+index 563dc93a5..3d919577e 100644
 --- a/dts/bindings/espi/microchip,xec-espi-v2.yaml
 +++ b/dts/bindings/espi/microchip,xec-espi-v2.yaml
 @@ -6,7 +6,7 @@ description: Microchip ESPI V2 controller
@@ -19435,14 +19173,13 @@ index 563dc93a52..3d919577e7 100644
        type: int
        const: 1
 -- 
-2.17.1
+2.25.1
 
 
-From 7c8f54ffd55f72098340ad6626c86d3f096807df Mon Sep 17 00:00:00 2001
+From f370a67ba22e210528e6cbd5096ccca856586146 Mon Sep 17 00:00:00 2001
 From: Jay Vasanth <jay.vasanth@microchip.com>
 Date: Fri, 21 Jan 2022 12:50:06 -0500
-Subject: [PATCH 054/112] [BACPORTED][MODIFIED] serial: update mchp uart module
- to use pinctrl
+Subject: [PATCH 053/111] serial: update mchp uart module to use pinctrl
 
 Changes to uart module to support pinctrl
 
@@ -19453,7 +19190,7 @@ Signed-off-by: Jay Vasanth <jay.vasanth@microchip.com>
  2 files changed, 18 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/serial/uart_mchp_xec.c b/drivers/serial/uart_mchp_xec.c
-index 0f329580ea..d8e116a1cb 100644
+index 0f329580e..d8e116a1c 100644
 --- a/drivers/serial/uart_mchp_xec.c
 +++ b/drivers/serial/uart_mchp_xec.c
 @@ -26,6 +26,7 @@
@@ -19503,7 +19240,7 @@ index 0f329580ea..d8e116a1cb 100644
  	};								\
  	static struct uart_xec_dev_data uart_xec_dev_data_##n = {	\
 diff --git a/dts/bindings/serial/microchip,xec-uart.yaml b/dts/bindings/serial/microchip,xec-uart.yaml
-index fd05b7735e..a7d1400d34 100644
+index fd05b7735..a7d1400d3 100644
 --- a/dts/bindings/serial/microchip,xec-uart.yaml
 +++ b/dts/bindings/serial/microchip,xec-uart.yaml
 @@ -2,7 +2,7 @@ description: Microchip XEC UART
@@ -19529,14 +19266,13 @@ index fd05b7735e..a7d1400d34 100644
        type: int
        const: 2
 -- 
-2.17.1
+2.25.1
 
 
-From c77714431d4e71b1a8c78989435259f16565ec3e Mon Sep 17 00:00:00 2001
+From 7c3975533272c7ede6d651bcb0e32aa70244906e Mon Sep 17 00:00:00 2001
 From: Jay Vasanth <jay.vasanth@microchip.com>
 Date: Fri, 21 Jan 2022 16:35:57 -0500
-Subject: [PATCH 055/112] [BACPORTED] qmspi: update MEC172x qmspi module for
- pinctrl
+Subject: [PATCH 054/111] qmspi: update MEC172x qmspi module for pinctrl
 
 Changes to qmspi module to support pinctrl
 
@@ -19547,7 +19283,7 @@ Signed-off-by: Jay Vasanth <jay.vasanth@microchip.com>
  2 files changed, 18 insertions(+), 155 deletions(-)
 
 diff --git a/drivers/spi/spi_xec_qmspi_ldma.c b/drivers/spi/spi_xec_qmspi_ldma.c
-index c99942e707..3738dc092a 100644
+index c99942e70..3738dc092 100644
 --- a/drivers/spi/spi_xec_qmspi_ldma.c
 +++ b/drivers/spi/spi_xec_qmspi_ldma.c
 @@ -12,7 +12,9 @@ LOG_MODULE_REGISTER(spi_xec, CONFIG_SPI_LOG_LEVEL);
@@ -19771,7 +19507,7 @@ index c99942e707..3738dc092a 100644
  	DEVICE_DT_INST_DEFINE(i, &qmspi_xec_init, NULL,			\
  		&qmspi_xec_data_##i, &qmspi_xec_config_##i,		\
 diff --git a/dts/bindings/spi/microchip,xec-qmspi-ldma.yaml b/dts/bindings/spi/microchip,xec-qmspi-ldma.yaml
-index baa2b24c9a..6410086ece 100644
+index baa2b24c9..6410086ec 100644
 --- a/dts/bindings/spi/microchip,xec-qmspi-ldma.yaml
 +++ b/dts/bindings/spi/microchip,xec-qmspi-ldma.yaml
 @@ -6,7 +6,7 @@ description: Microchip XEC QMSPI controller with local DMA
@@ -19797,14 +19533,13 @@ index baa2b24c9a..6410086ece 100644
        type: int
        required: false
 -- 
-2.17.1
+2.25.1
 
 
-From 53907f56ac68a6f7aa6956f0ad09b2e894e258bd Mon Sep 17 00:00:00 2001
+From 4b9f750a7664c9ed9e5453264105673fa1b44718 Mon Sep 17 00:00:00 2001
 From: Jay Vasanth <jay.vasanth@microchip.com>
 Date: Mon, 31 Jan 2022 17:13:38 -0500
-Subject: [PATCH 056/112] [BACPORTED] qmspi: MEC172x: fix unused variable
- warning
+Subject: [PATCH 055/111] qmspi: MEC172x: fix unused variable warning
 
 Fix unused variable warning when CONFIG_SPI_ASYNC
 is not defined
@@ -19815,7 +19550,7 @@ Signed-off-by: Jay Vasanth <jay.vasanth@microchip.com>
  1 file changed, 4 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/spi/spi_xec_qmspi_ldma.c b/drivers/spi/spi_xec_qmspi_ldma.c
-index 3738dc092a..e601b6c04c 100644
+index 3738dc092..e601b6c04 100644
 --- a/drivers/spi/spi_xec_qmspi_ldma.c
 +++ b/drivers/spi/spi_xec_qmspi_ldma.c
 @@ -1002,11 +1002,13 @@ void qmspi_xec_isr(const struct device *dev)
@@ -19835,14 +19570,13 @@ index 3738dc092a..e601b6c04c 100644
  	regs->IEN = 0;
  	data->qstatus = qstatus;
 -- 
-2.17.1
+2.25.1
 
 
-From d1c08da40cfde5e0b753532148846cc99f9fafdf Mon Sep 17 00:00:00 2001
+From 4a7d7959257a726e5d780e21fe7c90ba0fefcb03 Mon Sep 17 00:00:00 2001
 From: Jay Vasanth <jay.vasanth@microchip.com>
 Date: Mon, 31 Jan 2022 17:45:22 -0500
-Subject: [PATCH 057/112] [BACPORTED] adc: updates to MEC172x adc to support
- pinctrl
+Subject: [PATCH 056/111] adc: updates to MEC172x adc to support pinctrl
 
 Changes to adc module to support pinctrl.
 
@@ -19853,7 +19587,7 @@ Signed-off-by: Jay Vasanth <jay.vasanth@microchip.com>
  2 files changed, 19 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/adc/adc_mchp_xec_v2.c b/drivers/adc/adc_mchp_xec_v2.c
-index f9e455ae47..3fd9791de1 100644
+index f9e455ae4..3fd9791de 100644
 --- a/drivers/adc/adc_mchp_xec_v2.c
 +++ b/drivers/adc/adc_mchp_xec_v2.c
 @@ -12,6 +12,7 @@ LOG_MODULE_REGISTER(adc_mchp_xec);
@@ -19904,7 +19638,7 @@ index f9e455ae47..3fd9791de1 100644
  
  static struct adc_xec_data adc_xec_dev_data_0 = {
 diff --git a/dts/bindings/adc/microchip,xec-adc-v2.yaml b/dts/bindings/adc/microchip,xec-adc-v2.yaml
-index 479daa29d9..0df908c2f3 100644
+index 479daa29d..0df908c2f 100644
 --- a/dts/bindings/adc/microchip,xec-adc-v2.yaml
 +++ b/dts/bindings/adc/microchip,xec-adc-v2.yaml
 @@ -6,7 +6,7 @@ description: Microchip XEC ADC
@@ -19930,13 +19664,13 @@ index 479daa29d9..0df908c2f3 100644
        type: int
        const: 2
 -- 
-2.17.1
+2.25.1
 
 
-From 8f08b04fdcf450b7601fbc7f77bd42b281913fec Mon Sep 17 00:00:00 2001
+From 369e89b2bd9cc42c694bd7c9099ab8cee6cd77af Mon Sep 17 00:00:00 2001
 From: Jay Vasanth <jay.vasanth@microchip.com>
 Date: Fri, 21 Jan 2022 17:47:08 -0500
-Subject: [PATCH 058/112] [BACPORTED] pinmux: Remove pinmux.c source file
+Subject: [PATCH 057/111] pinmux: Remove pinmux.c source file
 
 Since we are moving to pinctrl, removing pinmux.c
 from mec172x board folder and removing pinmux from dts
@@ -19951,7 +19685,7 @@ Signed-off-by: Jay Vasanth <jay.vasanth@microchip.com>
  delete mode 100644 boards/arm/mec172xevb_assy6906/pinmux.c
 
 diff --git a/boards/arm/mec172xevb_assy6906/CMakeLists.txt b/boards/arm/mec172xevb_assy6906/CMakeLists.txt
-index a68877db7d..b220461649 100644
+index a68877db7..b22046164 100644
 --- a/boards/arm/mec172xevb_assy6906/CMakeLists.txt
 +++ b/boards/arm/mec172xevb_assy6906/CMakeLists.txt
 @@ -5,7 +5,6 @@
@@ -19963,7 +19697,7 @@ index a68877db7d..b220461649 100644
  if(DEFINED ENV{MEC172X_SPI_GEN})
    # Grab it from environment variable if defined
 diff --git a/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906_defconfig b/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906_defconfig
-index 7487c8f9c2..a0a545e136 100644
+index 7487c8f9c..a0a545e13 100644
 --- a/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906_defconfig
 +++ b/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906_defconfig
 @@ -11,7 +11,6 @@ CONFIG_RTOS_TIMER=y
@@ -19976,7 +19710,7 @@ index 7487c8f9c2..a0a545e136 100644
  CONFIG_CONSOLE=y
 diff --git a/boards/arm/mec172xevb_assy6906/pinmux.c b/boards/arm/mec172xevb_assy6906/pinmux.c
 deleted file mode 100644
-index 36ea01184a..0000000000
+index 36ea01184..000000000
 --- a/boards/arm/mec172xevb_assy6906/pinmux.c
 +++ /dev/null
 @@ -1,205 +0,0 @@
@@ -20186,7 +19920,7 @@ index 36ea01184a..0000000000
 -
 -SYS_INIT(board_pinmux_init, PRE_KERNEL_1, CONFIG_PINMUX_INIT_PRIORITY);
 diff --git a/dts/arm/microchip/mec172xnsz.dtsi b/dts/arm/microchip/mec172xnsz.dtsi
-index e36f964c1f..1d0daa3566 100644
+index e36f964c1..1d0daa356 100644
 --- a/dts/arm/microchip/mec172xnsz.dtsi
 +++ b/dts/arm/microchip/mec172xnsz.dtsi
 @@ -34,35 +34,6 @@
@@ -20226,14 +19960,13 @@ index e36f964c1f..1d0daa3566 100644
  		ecs: ecs@4000fc00 {
  			reg = <0x4000fc00 0x200>;
 -- 
-2.17.1
+2.25.1
 
 
-From 4ca1b7d0178b848787e07ae84ebf5fe78378d208 Mon Sep 17 00:00:00 2001
+From 1c463815b38c398826441825fa4019579fe7151a Mon Sep 17 00:00:00 2001
 From: Jay Vasanth <jay.vasanth@microchip.com>
 Date: Thu, 24 Feb 2022 15:35:51 -0500
-Subject: [PATCH 059/112] [BACPORTED] kscan: update mchp keyscan module to use
- pinctrl
+Subject: [PATCH 058/111] kscan: update mchp keyscan module to use pinctrl
 
 Changes to keyscan module to support pinctrl
 
@@ -20246,7 +19979,7 @@ Signed-off-by: Jay Vasanth <jay.vasanth@microchip.com>
  4 files changed, 65 insertions(+), 14 deletions(-)
 
 diff --git a/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts b/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts
-index 9108c69f5d..e76e54e44e 100644
+index 9108c69f5..e76e54e44 100644
 --- a/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts
 +++ b/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts
 @@ -208,4 +208,28 @@
@@ -20279,7 +20012,7 @@ index 9108c69f5d..e76e54e44e 100644
 +	pinctrl-names = "default";
  };
 diff --git a/drivers/kscan/kscan_mchp_xec.c b/drivers/kscan/kscan_mchp_xec.c
-index 17d99d2404..661ffd9abb 100644
+index 17d99d240..661ffd9ab 100644
 --- a/drivers/kscan/kscan_mchp_xec.c
 +++ b/drivers/kscan/kscan_mchp_xec.c
 @@ -6,16 +6,21 @@
@@ -20381,7 +20114,7 @@ index 17d99d2404..661ffd9abb 100644
  };
  
 diff --git a/dts/arm/microchip/mec1501hsz.dtsi b/dts/arm/microchip/mec1501hsz.dtsi
-index 4448dd4fa4..564ab0b09a 100644
+index 4448dd4fa..564ab0b09 100644
 --- a/dts/arm/microchip/mec1501hsz.dtsi
 +++ b/dts/arm/microchip/mec1501hsz.dtsi
 @@ -414,6 +414,8 @@
@@ -20394,7 +20127,7 @@ index 4448dd4fa4..564ab0b09a 100644
  			status = "disabled";
  			#address-cells = <1>;
 diff --git a/dts/bindings/kscan/microchip,xec-kscan.yaml b/dts/bindings/kscan/microchip,xec-kscan.yaml
-index 70e149c52b..1c6389028c 100644
+index 70e149c52..1c6389028 100644
 --- a/dts/bindings/kscan/microchip,xec-kscan.yaml
 +++ b/dts/bindings/kscan/microchip,xec-kscan.yaml
 @@ -6,7 +6,7 @@ description: Microchip XEC keyboard matrix controller
@@ -20433,14 +20166,13 @@ index 70e149c52b..1c6389028c 100644
  
  girq-cells:
 -- 
-2.17.1
+2.25.1
 
 
-From c077e282738263bdedfc492ec132ddb08b00e62f Mon Sep 17 00:00:00 2001
+From 6dfd660d15a001fda76ae080fe0e37eef44cc192 Mon Sep 17 00:00:00 2001
 From: Jay Vasanth <jay.vasanth@microchip.com>
 Date: Mon, 28 Feb 2022 12:42:52 -0500
-Subject: [PATCH 060/112] [BACKPORTED] drivers: bbram: mec: fixed compilation
- error
+Subject: [PATCH 059/111] drivers: bbram: mec: fixed compilation error
 
 Fixed compilation error when building bbram driver
 for MEC15xx
@@ -20451,7 +20183,7 @@ Signed-off-by: Jay Vasanth <jay.vasanth@microchip.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/bbram/bbram_xec.c b/drivers/bbram/bbram_xec.c
-index 6b3c0d7fc1..83b68cfb91 100644
+index 6b3c0d7fc..83b68cfb9 100644
 --- a/drivers/bbram/bbram_xec.c
 +++ b/drivers/bbram/bbram_xec.c
 @@ -25,7 +25,7 @@ struct bbram_xec_config {
@@ -20464,14 +20196,13 @@ index 6b3c0d7fc1..83b68cfb91 100644
  	if (regs->PFRS & BIT(MCHP_VBATR_PFRS_VBAT_RST_POS)) {
  		regs->PFRS |= BIT(MCHP_VBATR_PFRS_VBAT_RST_POS);
 -- 
-2.17.1
+2.25.1
 
 
-From f4e98224a86c9ee103131f90c2b2039e01bc8637 Mon Sep 17 00:00:00 2001
+From 8b6fc4e862db003c9efc00e6942f58c063ea3ced Mon Sep 17 00:00:00 2001
 From: Frances Wu <frances.wu@microchip.com>
 Date: Mon, 7 Mar 2022 13:56:32 -0800
-Subject: [PATCH 061/112] [BACKPORTED] mec172xevb_assy6906: update:
- documentation
+Subject: [PATCH 060/111] mec172xevb_assy6906: update: documentation
 
 Update mec172xevb_assy6906 documentation to include the correct
 jumper settings. Fix documentation style issue. Clarify SPI image
@@ -27843,7 +27574,7 @@ literal 0
 HcmV?d00001
 
 diff --git a/boards/arm/mec172xevb_assy6906/doc/index.rst b/boards/arm/mec172xevb_assy6906/doc/index.rst
-index 6eed26fa32..159eb2f2ae 100644
+index 6eed26fa3..159eb2f2a 100644
 --- a/boards/arm/mec172xevb_assy6906/doc/index.rst
 +++ b/boards/arm/mec172xevb_assy6906/doc/index.rst
 @@ -1,4 +1,4 @@
@@ -38702,14 +38433,14 @@ literal 0
 HcmV?d00001
 
 -- 
-2.17.1
+2.25.1
 
 
-From e7d5ff450a2106645795c27e38ec2a4d31e6f4f4 Mon Sep 17 00:00:00 2001
+From b2e237f6b8a12f77624ad4a225c8f4814209ec71 Mon Sep 17 00:00:00 2001
 From: Jose Alberto Meza <jose.a.meza.arellano@intel.com>
 Date: Mon, 28 Feb 2022 17:15:42 -0800
-Subject: [PATCH 062/112] [BACKPORTED] drivers: espi: xec: mec172x: Handle eSPI
- peripheral channel error
+Subject: [PATCH 061/111] drivers: espi: xec: mec172x: Handle eSPI peripheral
+ channel error
 
 Handle eSPI periperal channel error to avoid continous interrupt
 beyond the bus error.
@@ -38724,7 +38455,7 @@ Signed-off-by: Jose Alberto Meza <jose.a.meza.arellano@intel.com>
  1 file changed, 6 insertions(+)
 
 diff --git a/drivers/espi/espi_mchp_xec_v2.c b/drivers/espi/espi_mchp_xec_v2.c
-index 9dc37d35ff..bfdbc56c26 100644
+index 9dc37d35f..bfdbc56c2 100644
 --- a/drivers/espi/espi_mchp_xec_v2.c
 +++ b/drivers/espi/espi_mchp_xec_v2.c
 @@ -852,6 +852,12 @@ static void espi_pc_isr(const struct device *dev)
@@ -38741,14 +38472,13 @@ index 9dc37d35ff..bfdbc56c26 100644
  		if (status & MCHP_ESPI_PC_STS_EN) {
  			setup_espi_io_config(dev, MCHP_ESPI_IOBAR_INIT_DFLT);
 -- 
-2.17.1
+2.25.1
 
 
-From 49f97f1a085c7811e02bc9ede507adfa68c343df Mon Sep 17 00:00:00 2001
+From 1bbe6f34c2c090d737e79a20e58777b3f0f32f3b Mon Sep 17 00:00:00 2001
 From: Jay Vasanth <jay.vasanth@microchip.com>
 Date: Fri, 11 Mar 2022 14:37:39 -0500
-Subject: [PATCH 063/112] [BACKPORTED] drivers: pwm: Microchip XEC PWM add
- MEC172x support
+Subject: [PATCH 062/111] drivers: pwm: Microchip XEC PWM add MEC172x support
 
 Add support for MEC172x series to Microchip XEC PWM driver.
 Standardize device tree properties for both SoC families.
@@ -38762,7 +38492,7 @@ Signed-off-by: Jay Vasanth <jay.vasanth@microchip.com>
  3 files changed, 86 insertions(+), 61 deletions(-)
 
 diff --git a/drivers/pwm/pwm_mchp_xec.c b/drivers/pwm/pwm_mchp_xec.c
-index 3b639f54fe..a93c4dd834 100644
+index 3b639f54f..a93c4dd83 100644
 --- a/drivers/pwm/pwm_mchp_xec.c
 +++ b/drivers/pwm/pwm_mchp_xec.c
 @@ -1,22 +1,30 @@
@@ -39008,7 +38738,7 @@ index 3b639f54fe..a93c4dd834 100644
 +
 +DT_INST_FOREACH_STATUS_OKAY(XEC_PWM_DEVICE_INIT)
 diff --git a/dts/arm/microchip/mec1501hsz.dtsi b/dts/arm/microchip/mec1501hsz.dtsi
-index 564ab0b09a..c116ba132d 100644
+index 564ab0b09..c116ba132 100644
 --- a/dts/arm/microchip/mec1501hsz.dtsi
 +++ b/dts/arm/microchip/mec1501hsz.dtsi
 @@ -341,6 +341,7 @@
@@ -39084,7 +38814,7 @@ index 564ab0b09a..c116ba132d 100644
  			status = "disabled";
  			#pwm-cells = <1>;
 diff --git a/dts/arm/microchip/mec172xnsz.dtsi b/dts/arm/microchip/mec172xnsz.dtsi
-index 1d0daa3566..8b31f5288e 100644
+index 1d0daa356..8b31f5288 100644
 --- a/dts/arm/microchip/mec172xnsz.dtsi
 +++ b/dts/arm/microchip/mec172xnsz.dtsi
 @@ -587,6 +587,7 @@
@@ -39160,14 +38890,14 @@ index 1d0daa3566..8b31f5288e 100644
  			pcrs = <1 27>;
  			label = "PWM_8";
 -- 
-2.17.1
+2.25.1
 
 
-From 03a1f6cffe259ca97b94b8dd2568c0c6756d0a4f Mon Sep 17 00:00:00 2001
+From 542f7c96700d98bfec4c53c0cc6d7769a89b6069 Mon Sep 17 00:00:00 2001
 From: Jay Vasanth <jay.vasanth@microchip.com>
 Date: Fri, 11 Mar 2022 14:52:59 -0500
-Subject: [PATCH 064/112] [BACKPORTED][MANUAL MERGE] drivers: pwm: Microchp XEC
- PWM driver add PINCTRL support
+Subject: [PATCH 063/111] drivers: pwm: Microchp XEC PWM driver add PINCTRL
+ support
 
 Add build time optional PINCTRL support to common PWM driver
 for Microchip XEC MEC15xx and MEC172x families.
@@ -39181,7 +38911,7 @@ Signed-off-by: Jay Vasanth <jay.vasanth@microchip.com>
  4 files changed, 51 insertions(+), 5 deletions(-)
 
 diff --git a/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts b/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts
-index e76e54e44e..026c3ed5f9 100644
+index e76e54e44..026c3ed5f 100644
 --- a/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts
 +++ b/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts
 @@ -233,3 +233,9 @@
@@ -39195,7 +38925,7 @@ index e76e54e44e..026c3ed5f9 100644
 +	pinctrl-names = "default";
 +};
 diff --git a/drivers/pwm/Kconfig.xec b/drivers/pwm/Kconfig.xec
-index f54b54dd16..19f1815f93 100644
+index f54b54dd1..19f1815f9 100644
 --- a/drivers/pwm/Kconfig.xec
 +++ b/drivers/pwm/Kconfig.xec
 @@ -6,5 +6,6 @@
@@ -39206,7 +38936,7 @@ index f54b54dd16..19f1815f93 100644
  	help
  	  Enable driver to utilize PWM on the Microchip XEC IP block.
 diff --git a/drivers/pwm/pwm_mchp_xec.c b/drivers/pwm/pwm_mchp_xec.c
-index a93c4dd834..a8e92b28f7 100644
+index a93c4dd83..a8e92b28f 100644
 --- a/drivers/pwm/pwm_mchp_xec.c
 +++ b/drivers/pwm/pwm_mchp_xec.c
 @@ -9,17 +9,19 @@
@@ -39290,7 +39020,7 @@ index a93c4dd834..a8e92b28f7 100644
  									\
  	DEVICE_DT_INST_DEFINE(index, &pwm_xec_init,			\
 diff --git a/dts/bindings/pwm/microchip,xec-pwm.yaml b/dts/bindings/pwm/microchip,xec-pwm.yaml
-index 4a292968fb..74f3b3cb37 100644
+index 4a292968f..74f3b3cb3 100644
 --- a/dts/bindings/pwm/microchip,xec-pwm.yaml
 +++ b/dts/bindings/pwm/microchip,xec-pwm.yaml
 @@ -3,7 +3,7 @@
@@ -39318,14 +39048,13 @@ index 4a292968fb..74f3b3cb37 100644
  pwm-cells:
    - channel
 -- 
-2.17.1
+2.25.1
 
 
-From 40159afacb62d6477c7b1f3c970ac82f6279826f Mon Sep 17 00:00:00 2001
+From 411b93b14593dc79fe21091849129d3c5a588e47 Mon Sep 17 00:00:00 2001
 From: Jay Vasanth <jay.vasanth@microchip.com>
 Date: Thu, 17 Mar 2022 16:43:00 -0400
-Subject: [PATCH 065/112] [BACKPORTED] soc: arm: microchip_mec: Remove unused
- soc_espi_v2.h
+Subject: [PATCH 064/111] soc: arm: microchip_mec: Remove unused soc_espi_v2.h
 
 Remove unused MEC172x header file soc_espi_v2.h
 
@@ -39338,7 +39067,7 @@ Signed-off-by: Jay Vasanth <jay.vasanth@microchip.com>
 
 diff --git a/soc/arm/microchip_mec/common/soc_espi_v2.h b/soc/arm/microchip_mec/common/soc_espi_v2.h
 deleted file mode 100644
-index 64486b78ca..0000000000
+index 64486b78c..000000000
 --- a/soc/arm/microchip_mec/common/soc_espi_v2.h
 +++ /dev/null
 @@ -1,22 +0,0 @@
@@ -39365,7 +39094,7 @@ index 64486b78ca..0000000000
 -
 -#endif /* _SOC_ESPI_V2_H_ */
 diff --git a/soc/arm/microchip_mec/mec172x/soc.h b/soc/arm/microchip_mec/mec172x/soc.h
-index 092db77e3b..1ee8a991d1 100644
+index 092db77e3..1ee8a991d 100644
 --- a/soc/arm/microchip_mec/mec172x/soc.h
 +++ b/soc/arm/microchip_mec/mec172x/soc.h
 @@ -282,7 +282,6 @@ typedef enum {
@@ -39377,14 +39106,14 @@ index 092db77e3b..1ee8a991d1 100644
  
  #endif
 -- 
-2.17.1
+2.25.1
 
 
-From 185af56279259519adbde09ad886f964b08915f3 Mon Sep 17 00:00:00 2001
+From b344635aeda27340feee63440063d37668853ff4 Mon Sep 17 00:00:00 2001
 From: Jeff Daly <jeffd@silicom-usa.com>
 Date: Mon, 21 Mar 2022 08:26:01 -0400
-Subject: [PATCH 066/112] [BACKPORTED] Microchip: MEC172x fix kbc IBF direct
- NVIC input number
+Subject: [PATCH 065/111] Microchip: MEC172x fix kbc IBF direct NVIC input
+ number
 
 Fixed 8042 IBF direct NVIC input number.
 
@@ -39394,7 +39123,7 @@ Signed-off-by: Jeff Daly <jeffd@silicom-usa.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/dts/arm/microchip/mec172xnsz.dtsi b/dts/arm/microchip/mec172xnsz.dtsi
-index 8b31f5288e..927c827cd9 100644
+index 8b31f5288..927c827cd 100644
 --- a/dts/arm/microchip/mec172xnsz.dtsi
 +++ b/dts/arm/microchip/mec172xnsz.dtsi
 @@ -908,7 +908,7 @@
@@ -39407,14 +39136,14 @@ index 8b31f5288e..927c827cd9 100644
  				label = "KBC_0";
  				status = "disabled";
 -- 
-2.17.1
+2.25.1
 
 
-From e710e8534ca2462d9971c7afc58caa1b696adf58 Mon Sep 17 00:00:00 2001
+From 60c677dd69b5716f8d90bbe46be6a89a977b6a36 Mon Sep 17 00:00:00 2001
 From: Jeff Daly <jeffd@silicom-usa.com>
 Date: Mon, 21 Mar 2022 09:01:00 -0400
-Subject: [PATCH 067/112] [BACKPORTED] Microchip: MEC172x fix acpi_ec direct
- NVIC input numbers
+Subject: [PATCH 066/111] Microchip: MEC172x fix acpi_ec direct NVIC input
+ numbers
 
 Fix the direct NVIC input numbers for acpi_ec[1-4].
 
@@ -39424,7 +39153,7 @@ Signed-off-by: Jeff Daly <jeffd@silicom-usa.com>
  1 file changed, 11 insertions(+), 11 deletions(-)
 
 diff --git a/dts/arm/microchip/mec172xnsz.dtsi b/dts/arm/microchip/mec172xnsz.dtsi
-index 927c827cd9..4d8de186f1 100644
+index 927c827cd..4d8de186f 100644
 --- a/dts/arm/microchip/mec172xnsz.dtsi
 +++ b/dts/arm/microchip/mec172xnsz.dtsi
 @@ -929,8 +929,8 @@
@@ -39485,14 +39214,14 @@ index 927c827cd9..4d8de186f1 100644
  				label = "ACPI_PM1";
  				status = "disabled";
 -- 
-2.17.1
+2.25.1
 
 
-From 7fa95a14ba96b287fd433ec3d110136d1deef99f Mon Sep 17 00:00:00 2001
+From a2f61ceb1c7b35eee94a65d43257b9dc14b5cb79 Mon Sep 17 00:00:00 2001
 From: Jeff Daly <jeffd@silicom-usa.com>
 Date: Tue, 22 Mar 2022 16:54:03 -0400
-Subject: [PATCH 068/112] [BACKPORTED] Microchip: MEC172x fix p80bd0 direct
- NVIC input number
+Subject: [PATCH 067/111] Microchip: MEC172x fix p80bd0 direct NVIC input
+ number
 
 Fixed Port 80 direct NVIC input number.
 
@@ -39502,7 +39231,7 @@ Signed-off-by: Jeff Daly <jeffd@silicom-usa.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/dts/arm/microchip/mec172xnsz.dtsi b/dts/arm/microchip/mec172xnsz.dtsi
-index 4d8de186f1..ea12b10cf5 100644
+index 4d8de186f..ea12b10cf 100644
 --- a/dts/arm/microchip/mec172xnsz.dtsi
 +++ b/dts/arm/microchip/mec172xnsz.dtsi
 @@ -1054,7 +1054,7 @@
@@ -39515,14 +39244,13 @@ index 4d8de186f1..ea12b10cf5 100644
  				ldn = <32>;
  				label = "P80BD_0";
 -- 
-2.17.1
+2.25.1
 
 
-From 1673d905956b49c1246ae7d47502c12f21ffc7cd Mon Sep 17 00:00:00 2001
+From 16fed7e419c72a0d88eb5f217329d3f02d7a0718 Mon Sep 17 00:00:00 2001
 From: Jose Alberto Meza <jose.a.meza.arellano@intel.com>
 Date: Fri, 25 Mar 2022 18:51:11 -0700
-Subject: [PATCH 069/112] [BACKPORTED] soc: arm: microchip: mec172x: Fix PWM
- dependency
+Subject: [PATCH 068/111] soc: arm: microchip: mec172x: Fix PWM dependency
 
 Enable PWM_XEC whenever CONFIG_PWM is selected
 
@@ -39532,7 +39260,7 @@ Signed-off-by: Jose Alberto Meza <jose.a.meza.arellano@intel.com>
  1 file changed, 4 insertions(+)
 
 diff --git a/soc/arm/microchip_mec/mec172x/Kconfig.defconfig.mec172xnsz b/soc/arm/microchip_mec/mec172x/Kconfig.defconfig.mec172xnsz
-index dfc41faa4a..456a8363ab 100644
+index dfc41faa4..456a8363a 100644
 --- a/soc/arm/microchip_mec/mec172x/Kconfig.defconfig.mec172xnsz
 +++ b/soc/arm/microchip_mec/mec172x/Kconfig.defconfig.mec172xnsz
 @@ -23,6 +23,10 @@ config PINMUX_XEC
@@ -39547,14 +39275,14 @@ index dfc41faa4a..456a8363ab 100644
  	default y
  	depends on ADC
 -- 
-2.17.1
+2.25.1
 
 
-From fa1ef34d013a978b3dc868e1530e51e58b27a0e0 Mon Sep 17 00:00:00 2001
+From 16723710eb01e27b472b4399ef29ae03ab950024 Mon Sep 17 00:00:00 2001
 From: Jose Alberto Meza <jose.a.meza.arellano@intel.com>
 Date: Thu, 31 Mar 2022 11:33:39 -0700
-Subject: [PATCH 070/112] [BACKPORTED] soc: arm: microchip: mec172x: Fix eSPI
- flash operations
+Subject: [PATCH 069/111] soc: arm: microchip: mec172x: Fix eSPI flash
+ operations
 
 Correct eSPI flash macro so it not always results in zero,
 leading to eSPI flash read operation in all cases:
@@ -39566,7 +39294,7 @@ Signed-off-by: Jose Alberto Meza <jose.a.meza.arellano@intel.com>
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/soc/arm/microchip_mec/mec172x/reg/mec172x_espi_iom.h b/soc/arm/microchip_mec/mec172x/reg/mec172x_espi_iom.h
-index 9146563122..d2501723cc 100644
+index 914656312..d2501723c 100644
 --- a/soc/arm/microchip_mec/mec172x/reg/mec172x_espi_iom.h
 +++ b/soc/arm/microchip_mec/mec172x/reg/mec172x_espi_iom.h
 @@ -385,7 +385,8 @@
@@ -39580,14 +39308,14 @@ index 9146563122..d2501723cc 100644
  #define MCHP_ESPI_FC_CTRL_TAG_POS	4u
  #define MCHP_ESPI_FC_CTRL_TAG_MASK0	0x0fu
 -- 
-2.17.1
+2.25.1
 
 
-From d3f3e86eebcf35774d2d393e58a728e4f20e425b Mon Sep 17 00:00:00 2001
+From 604ae77be20d48f7abdee9a63610615884346ffd Mon Sep 17 00:00:00 2001
 From: Jay Vasanth <jay.vasanth@microchip.com>
 Date: Fri, 11 Mar 2022 16:38:56 -0500
-Subject: [PATCH 071/112] [BACKPORTED] drivers: tach: Microchip XEC TACH driver
- add MEC172x support
+Subject: [PATCH 070/111] drivers: tach: Microchip XEC TACH driver add MEC172x
+ support
 
 Update Microchip XEC TACH driver to support MEC172x.
 Standardize device tree properties between chips.
@@ -39603,7 +39331,7 @@ Signed-off-by: Jay Vasanth <jay.vasanth@microchip.com>
  5 files changed, 86 insertions(+), 27 deletions(-)
 
 diff --git a/boards/arm/mec172xevb_assy6906/Kconfig.defconfig b/boards/arm/mec172xevb_assy6906/Kconfig.defconfig
-index 8b23b520e1..957af973c7 100644
+index 8b23b520e..957af973c 100644
 --- a/boards/arm/mec172xevb_assy6906/Kconfig.defconfig
 +++ b/boards/arm/mec172xevb_assy6906/Kconfig.defconfig
 @@ -36,4 +36,8 @@ config SYS_CLOCK_TICKS_PER_SEC
@@ -39616,7 +39344,7 @@ index 8b23b520e1..957af973c7 100644
 +
  endif # BOARD_MEC172XEVB_ASSY6906
 diff --git a/drivers/sensor/mchp_tach_xec/tach_mchp_xec.c b/drivers/sensor/mchp_tach_xec/tach_mchp_xec.c
-index 054686e20b..b0a6ed6051 100644
+index 054686e20..b0a6ed605 100644
 --- a/drivers/sensor/mchp_tach_xec/tach_mchp_xec.c
 +++ b/drivers/sensor/mchp_tach_xec/tach_mchp_xec.c
 @@ -1,5 +1,6 @@
@@ -39758,7 +39486,7 @@ index 054686e20b..b0a6ed6051 100644
  			    CONFIG_SENSOR_INIT_PRIORITY,		\
  			    &tach_xec_driver_api);
 diff --git a/dts/arm/microchip/mec1501hsz.dtsi b/dts/arm/microchip/mec1501hsz.dtsi
-index c116ba132d..5eb9a209c5 100644
+index c116ba132..5eb9a209c 100644
 --- a/dts/arm/microchip/mec1501hsz.dtsi
 +++ b/dts/arm/microchip/mec1501hsz.dtsi
 @@ -460,6 +460,8 @@
@@ -39798,7 +39526,7 @@ index c116ba132d..5eb9a209c5 100644
  			status = "disabled";
  			#address-cells = <1>;
 diff --git a/dts/arm/microchip/mec172xnsz.dtsi b/dts/arm/microchip/mec172xnsz.dtsi
-index ea12b10cf5..9fb13b2b03 100644
+index ea12b10cf..9fb13b2b0 100644
 --- a/dts/arm/microchip/mec172xnsz.dtsi
 +++ b/dts/arm/microchip/mec172xnsz.dtsi
 @@ -659,6 +659,7 @@
@@ -39834,7 +39562,7 @@ index ea12b10cf5..9fb13b2b03 100644
  			interrupts = <159 4>;
  			girqs = <17 4>;
 diff --git a/dts/bindings/tach/microchip,xec-tach.yaml b/dts/bindings/tach/microchip,xec-tach.yaml
-index be849a0da0..7b5f6054a2 100644
+index be849a0da..7b5f6054a 100644
 --- a/dts/bindings/tach/microchip,xec-tach.yaml
 +++ b/dts/bindings/tach/microchip,xec-tach.yaml
 @@ -19,3 +19,23 @@ properties:
@@ -39862,14 +39590,14 @@ index be849a0da0..7b5f6054a2 100644
 +    - regidx
 +    - bitpos
 -- 
-2.17.1
+2.25.1
 
 
-From fb9ab48b43a0c5fa1644d972823357b3d62f87ef Mon Sep 17 00:00:00 2001
+From 8c10434e72f2e1b513d3d0573efd986f8c95e056 Mon Sep 17 00:00:00 2001
 From: Jay Vasanth <jay.vasanth@microchip.com>
 Date: Fri, 11 Mar 2022 16:44:39 -0500
-Subject: [PATCH 072/112] [BACKPORTED] drivers: tach: Microchip XEC TACH driver
- add PINCTRL support
+Subject: [PATCH 071/111] drivers: tach: Microchip XEC TACH driver add PINCTRL
+ support
 
 Add build time optional PINCTRL support to the Microchip XEC TACH
 driver shared by MEC15xx and MEC172x families.
@@ -39882,7 +39610,7 @@ Signed-off-by: Jay Vasanth <jay.vasanth@microchip.com>
  3 files changed, 38 insertions(+), 1 deletion(-)
 
 diff --git a/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts b/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts
-index 026c3ed5f9..3fe63c9fac 100644
+index 026c3ed5f..3fe63c9fa 100644
 --- a/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts
 +++ b/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts
 @@ -239,3 +239,9 @@
@@ -39896,7 +39624,7 @@ index 026c3ed5f9..3fe63c9fac 100644
 +	pinctrl-names = "default";
 +};
 diff --git a/drivers/sensor/mchp_tach_xec/tach_mchp_xec.c b/drivers/sensor/mchp_tach_xec/tach_mchp_xec.c
-index b0a6ed6051..9ce1e6e554 100644
+index b0a6ed605..9ce1e6e55 100644
 --- a/drivers/sensor/mchp_tach_xec/tach_mchp_xec.c
 +++ b/drivers/sensor/mchp_tach_xec/tach_mchp_xec.c
 @@ -13,6 +13,9 @@
@@ -39971,7 +39699,7 @@ index b0a6ed6051..9ce1e6e554 100644
  									\
  	DEVICE_DT_INST_DEFINE(id,					\
 diff --git a/dts/bindings/tach/microchip,xec-tach.yaml b/dts/bindings/tach/microchip,xec-tach.yaml
-index 7b5f6054a2..409cf6c4ff 100644
+index 7b5f6054a..409cf6c4f 100644
 --- a/dts/bindings/tach/microchip,xec-tach.yaml
 +++ b/dts/bindings/tach/microchip,xec-tach.yaml
 @@ -5,7 +5,7 @@ description: Microchip XEC tachometer controller
@@ -39984,14 +39712,13 @@ index 7b5f6054a2..409cf6c4ff 100644
  properties:
      "#address-cells":
 -- 
-2.17.1
+2.25.1
 
 
-From 095985ec0ccf5bdabf9873537ccccfa5eb34b226 Mon Sep 17 00:00:00 2001
+From 56b377687afee60b69c80342159ca0034b4a5904 Mon Sep 17 00:00:00 2001
 From: Jay Vasanth <jay.vasanth@microchip.com>
 Date: Thu, 24 Mar 2022 14:28:59 -0400
-Subject: [PATCH 073/112] [BACKPORTED] drivers: peci: Microchip XEC PECI driver
- standardize
+Subject: [PATCH 072/111] drivers: peci: Microchip XEC PECI driver standardize
 
 Standarize device structure usage for mchp peci driver
 
@@ -40003,7 +39730,7 @@ Signed-off-by: Jay Vasanth <jay.vasanth@microchip.com>
  3 files changed, 145 insertions(+), 84 deletions(-)
 
 diff --git a/drivers/peci/peci_mchp_xec.c b/drivers/peci/peci_mchp_xec.c
-index 519ab20518..04946df635 100644
+index 519ab2051..04946df63 100644
 --- a/drivers/peci/peci_mchp_xec.c
 +++ b/drivers/peci/peci_mchp_xec.c
 @@ -35,8 +35,12 @@ LOG_MODULE_REGISTER(peci_mchp_xec, CONFIG_PECI_LOG_LEVEL);
@@ -40460,7 +40187,7 @@ index 519ab20518..04946df635 100644
  		    POST_KERNEL, CONFIG_PECI_INIT_PRIORITY,
  		    &peci_xec_driver_api);
 diff --git a/dts/arm/microchip/mec1501hsz.dtsi b/dts/arm/microchip/mec1501hsz.dtsi
-index 5eb9a209c5..68b5a3a0a7 100644
+index 5eb9a209c..68b5a3a0a 100644
 --- a/dts/arm/microchip/mec1501hsz.dtsi
 +++ b/dts/arm/microchip/mec1501hsz.dtsi
 @@ -434,6 +434,8 @@
@@ -40473,7 +40200,7 @@ index 5eb9a209c5..68b5a3a0a7 100644
  			#address-cells = <1>;
  			#size-cells = <0>;
 diff --git a/dts/bindings/peci/microchip,xec-peci.yaml b/dts/bindings/peci/microchip,xec-peci.yaml
-index 69b95fae52..668e125c70 100644
+index 69b95fae5..668e125c7 100644
 --- a/dts/bindings/peci/microchip,xec-peci.yaml
 +++ b/dts/bindings/peci/microchip,xec-peci.yaml
 @@ -13,3 +13,21 @@ properties:
@@ -40499,14 +40226,14 @@ index 69b95fae52..668e125c70 100644
 +    - regidx
 +    - bitpos
 -- 
-2.17.1
+2.25.1
 
 
-From 3f6c1ed706322a1b2660d7435afa0248c1092a39 Mon Sep 17 00:00:00 2001
+From 4570aac0b02d9c9bdb044901e73b849fb1111fe5 Mon Sep 17 00:00:00 2001
 From: Jay Vasanth <jay.vasanth@microchip.com>
 Date: Thu, 24 Mar 2022 14:28:59 -0400
-Subject: [PATCH 074/112] [BACKPORTED] drivers: peci: Microchip XEC PECI driver
- add MEC172x support
+Subject: [PATCH 073/111] drivers: peci: Microchip XEC PECI driver add MEC172x
+ support
 
 Update Microchip XEC PECI driver to support MEC172x.
 
@@ -40519,7 +40246,7 @@ Signed-off-by: Jay Vasanth <jay.vasanth@microchip.com>
  4 files changed, 33 insertions(+)
 
 diff --git a/drivers/peci/Kconfig.xec b/drivers/peci/Kconfig.xec
-index 7e6e49d534..4d3aec65d5 100644
+index 7e6e49d53..4d3aec65d 100644
 --- a/drivers/peci/Kconfig.xec
 +++ b/drivers/peci/Kconfig.xec
 @@ -6,5 +6,6 @@
@@ -40530,7 +40257,7 @@ index 7e6e49d534..4d3aec65d5 100644
  	help
  	  Enable the Microchip XEC PECI IO driver.
 diff --git a/drivers/peci/peci_mchp_xec.c b/drivers/peci/peci_mchp_xec.c
-index 04946df635..64f3f8c46e 100644
+index 04946df63..64f3f8c46 100644
 --- a/drivers/peci/peci_mchp_xec.c
 +++ b/drivers/peci/peci_mchp_xec.c
 @@ -8,6 +8,10 @@
@@ -40582,7 +40309,7 @@ index 04946df635..64f3f8c46e 100644
  static int check_bus_idle(struct peci_regs * const regs)
  {
 diff --git a/dts/arm/microchip/mec172xnsz.dtsi b/dts/arm/microchip/mec172xnsz.dtsi
-index 9fb13b2b03..f2c9e7a389 100644
+index 9fb13b2b0..f2c9e7a38 100644
 --- a/dts/arm/microchip/mec172xnsz.dtsi
 +++ b/dts/arm/microchip/mec172xnsz.dtsi
 @@ -740,6 +740,7 @@
@@ -40594,7 +40321,7 @@ index 9fb13b2b03..f2c9e7a389 100644
  			interrupts = <70 4>;
  			girqs = <17 0>;
 diff --git a/soc/arm/microchip_mec/mec172x/Kconfig.defconfig.mec172xnsz b/soc/arm/microchip_mec/mec172x/Kconfig.defconfig.mec172xnsz
-index 456a8363ab..75c3717f18 100644
+index 456a8363a..75c3717f1 100644
 --- a/soc/arm/microchip_mec/mec172x/Kconfig.defconfig.mec172xnsz
 +++ b/soc/arm/microchip_mec/mec172x/Kconfig.defconfig.mec172xnsz
 @@ -43,4 +43,8 @@ config SPI_XEC_QMSPI_LDMA
@@ -40607,14 +40334,14 @@ index 456a8363ab..75c3717f18 100644
 +
  endif # SOC_MEC172X_NSZ
 -- 
-2.17.1
+2.25.1
 
 
-From f8e10b42a7fd99047fc5dd84b7e4c36ef7c49cfe Mon Sep 17 00:00:00 2001
+From 4a6bc74ea7895eed915ac45718a914bea63a71e8 Mon Sep 17 00:00:00 2001
 From: Jay Vasanth <jay.vasanth@microchip.com>
 Date: Thu, 24 Mar 2022 14:48:38 -0400
-Subject: [PATCH 075/112] [BACKPORTED] drivers: peci: Microchip XEC PECI driver
- add PINCTRL support
+Subject: [PATCH 074/111] drivers: peci: Microchip XEC PECI driver add PINCTRL
+ support
 
 Add PINCTRL support to Microchip XEC PECI driver shared by
 MEC172x and MEC15xx families.
@@ -40626,7 +40353,7 @@ Signed-off-by: Jay Vasanth <jay.vasanth@microchip.com>
  2 files changed, 34 insertions(+), 12 deletions(-)
 
 diff --git a/drivers/peci/peci_mchp_xec.c b/drivers/peci/peci_mchp_xec.c
-index 64f3f8c46e..703976d5f7 100644
+index 64f3f8c46..703976d5f 100644
 --- a/drivers/peci/peci_mchp_xec.c
 +++ b/drivers/peci/peci_mchp_xec.c
 @@ -13,6 +13,9 @@
@@ -40709,7 +40436,7 @@ index 64f3f8c46e..703976d5f7 100644
  		    &peci_xec_init,
  		    NULL,
 diff --git a/dts/bindings/peci/microchip,xec-peci.yaml b/dts/bindings/peci/microchip,xec-peci.yaml
-index 668e125c70..50fad603cc 100644
+index 668e125c7..50fad603c 100644
 --- a/dts/bindings/peci/microchip,xec-peci.yaml
 +++ b/dts/bindings/peci/microchip,xec-peci.yaml
 @@ -5,7 +5,7 @@ description: Microchip XEC PECI controller
@@ -40722,14 +40449,14 @@ index 668e125c70..50fad603cc 100644
  properties:
      reg:
 -- 
-2.17.1
+2.25.1
 
 
-From 2af5d43c8b0d220dfd461bf249b7d4b969409bd7 Mon Sep 17 00:00:00 2001
+From fd117ce343518c02c472f71bd7867aa75988c8f5 Mon Sep 17 00:00:00 2001
 From: Jose Alberto Meza <jose.a.meza.arellano@intel.com>
 Date: Thu, 17 Mar 2022 13:15:51 -0700
-Subject: [PATCH 076/112] [BACKPORTED] drivers: espi: xec: mec172x: Handle eSPI
- bus host enable
+Subject: [PATCH 075/111] drivers: espi: xec: mec172x: Handle eSPI bus host
+ enable
 
 Add eSPI bus host enable/disable events from eSPI host.
 
@@ -40739,7 +40466,7 @@ Signed-off-by: Jose Alberto Meza <jose.a.meza.arellano@intel.com>
  1 file changed, 14 insertions(+)
 
 diff --git a/drivers/espi/espi_mchp_xec_v2.c b/drivers/espi/espi_mchp_xec_v2.c
-index bfdbc56c26..21cba40ddd 100644
+index bfdbc56c2..21cba40dd 100644
 --- a/drivers/espi/espi_mchp_xec_v2.c
 +++ b/drivers/espi/espi_mchp_xec_v2.c
 @@ -851,6 +851,10 @@ static void espi_pc_isr(const struct device *dev)
@@ -40771,14 +40498,13 @@ index bfdbc56c26..21cba40ddd 100644
  }
  
 -- 
-2.17.1
+2.25.1
 
 
-From ec4694e85c4bbae54455cedd8a69e5756cdcbe36 Mon Sep 17 00:00:00 2001
+From b42f2d28e7eaa25d66bf2b5372d0985da9abac3b Mon Sep 17 00:00:00 2001
 From: Frances Wu <frances.wu@microchip.com>
 Date: Thu, 24 Mar 2022 14:28:00 -0700
-Subject: [PATCH 077/112] [BACKPORTED][UNDER REVIEW] mec172xmodular_assy6930:
- add board support
+Subject: [PATCH 076/111] mec172xmodular_assy6930: add board support
 
 Add board files for mec172xmodular_assy6930.  This is for
 MEC172x Modular Card support.
@@ -40810,7 +40536,7 @@ Signed-off-by: Jose Alberto Meza <jose.a.meza.arellano@intel.com>
 
 diff --git a/boards/arm/mec172xmodular_assy6930/CMakeLists.txt b/boards/arm/mec172xmodular_assy6930/CMakeLists.txt
 new file mode 100644
-index 0000000000..ed0e3e513d
+index 000000000..ed0e3e513
 --- /dev/null
 +++ b/boards/arm/mec172xmodular_assy6930/CMakeLists.txt
 @@ -0,0 +1,35 @@
@@ -40851,7 +40577,7 @@ index 0000000000..ed0e3e513d
 +endif()
 diff --git a/boards/arm/mec172xmodular_assy6930/Kconfig.board b/boards/arm/mec172xmodular_assy6930/Kconfig.board
 new file mode 100644
-index 0000000000..0b91640dcb
+index 000000000..0b91640dc
 --- /dev/null
 +++ b/boards/arm/mec172xmodular_assy6930/Kconfig.board
 @@ -0,0 +1,6 @@
@@ -40863,7 +40589,7 @@ index 0000000000..0b91640dcb
 +	depends on SOC_MEC172X_NSZ
 diff --git a/boards/arm/mec172xmodular_assy6930/Kconfig.defconfig b/boards/arm/mec172xmodular_assy6930/Kconfig.defconfig
 new file mode 100644
-index 0000000000..da62421fd5
+index 000000000..da62421fd
 --- /dev/null
 +++ b/boards/arm/mec172xmodular_assy6930/Kconfig.defconfig
 @@ -0,0 +1,43 @@
@@ -40912,7 +40638,7 @@ index 0000000000..da62421fd5
 +endif # BOARD_MEC172XMODULAR_ASSY6930
 diff --git a/boards/arm/mec172xmodular_assy6930/board.cmake b/boards/arm/mec172xmodular_assy6930/board.cmake
 new file mode 100644
-index 0000000000..0378852531
+index 000000000..037885253
 --- /dev/null
 +++ b/boards/arm/mec172xmodular_assy6930/board.cmake
 @@ -0,0 +1,11 @@
@@ -40929,7 +40655,7 @@ index 0000000000..0378852531
 +)
 diff --git a/boards/arm/mec172xmodular_assy6930/mec172xmodular_assy6930.dts b/boards/arm/mec172xmodular_assy6930/mec172xmodular_assy6930.dts
 new file mode 100644
-index 0000000000..8e0f6f79bd
+index 000000000..8e0f6f79b
 --- /dev/null
 +++ b/boards/arm/mec172xmodular_assy6930/mec172xmodular_assy6930.dts
 @@ -0,0 +1,236 @@
@@ -41171,7 +40897,7 @@ index 0000000000..8e0f6f79bd
 +};
 diff --git a/boards/arm/mec172xmodular_assy6930/mec172xmodular_assy6930.yaml b/boards/arm/mec172xmodular_assy6930/mec172xmodular_assy6930.yaml
 new file mode 100644
-index 0000000000..b43be89856
+index 000000000..b43be8985
 --- /dev/null
 +++ b/boards/arm/mec172xmodular_assy6930/mec172xmodular_assy6930.yaml
 @@ -0,0 +1,19 @@
@@ -41196,7 +40922,7 @@ index 0000000000..b43be89856
 +  - i2c
 diff --git a/boards/arm/mec172xmodular_assy6930/mec172xmodular_assy6930_defconfig b/boards/arm/mec172xmodular_assy6930/mec172xmodular_assy6930_defconfig
 new file mode 100644
-index 0000000000..7c197888fd
+index 000000000..7c197888f
 --- /dev/null
 +++ b/boards/arm/mec172xmodular_assy6930/mec172xmodular_assy6930_defconfig
 @@ -0,0 +1,22 @@
@@ -41224,7 +40950,7 @@ index 0000000000..7c197888fd
 +CONFIG_SPI_ASYNC=y
 diff --git a/boards/arm/mec172xmodular_assy6930/support/spi_cfg.txt b/boards/arm/mec172xmodular_assy6930/support/spi_cfg.txt
 new file mode 100644
-index 0000000000..9b0d207282
+index 000000000..9b0d20728
 --- /dev/null
 +++ b/boards/arm/mec172xmodular_assy6930/support/spi_cfg.txt
 @@ -0,0 +1,54 @@
@@ -41284,7 +41010,7 @@ index 0000000000..9b0d207282
 +Comp1DrvMask = 0x60
 diff --git a/boards/arm/mec172xmodular_assy6930/support/spi_cfg_128MBit.txt b/boards/arm/mec172xmodular_assy6930/support/spi_cfg_128MBit.txt
 new file mode 100644
-index 0000000000..aaa35716d6
+index 000000000..aaa35716d
 --- /dev/null
 +++ b/boards/arm/mec172xmodular_assy6930/support/spi_cfg_128MBit.txt
 @@ -0,0 +1,50 @@
@@ -41340,7 +41066,7 @@ index 0000000000..aaa35716d6
 +Comp1DrvMask = 0x60
 diff --git a/boards/arm/mec172xmodular_assy6930/support/spi_cfg_4MBit.txt b/boards/arm/mec172xmodular_assy6930/support/spi_cfg_4MBit.txt
 new file mode 100644
-index 0000000000..9b0d207282
+index 000000000..9b0d20728
 --- /dev/null
 +++ b/boards/arm/mec172xmodular_assy6930/support/spi_cfg_4MBit.txt
 @@ -0,0 +1,54 @@
@@ -41399,13 +41125,13 @@ index 0000000000..9b0d207282
 +Comp1DrvValue = 0x20
 +Comp1DrvMask = 0x60
 -- 
-2.17.1
+2.25.1
 
 
-From 5e44c6d74abefd1cfb1a15c5625bcd579fb0b02e Mon Sep 17 00:00:00 2001
+From a0253f029a33d3ee0bb23c8fc10256636f7e2888 Mon Sep 17 00:00:00 2001
 From: Jose Alberto Meza <jose.a.meza.arellano@intel.com>
 Date: Wed, 6 Apr 2022 10:11:19 -0700
-Subject: [PATCH 078/112] drivers: sensor: mchp_tach: Correct spelling header
+Subject: [PATCH 077/111] drivers: sensor: mchp_tach: Correct spelling header
 
 Correct spelling in copyright.
 
@@ -41415,7 +41141,7 @@ Signed-off-by: Jose Alberto Meza <jose.a.meza.arellano@intel.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/sensor/mchp_tach_xec/tach_mchp_xec.c b/drivers/sensor/mchp_tach_xec/tach_mchp_xec.c
-index 9ce1e6e554..3d61a6eaa6 100644
+index 9ce1e6e55..3d61a6eaa 100644
 --- a/drivers/sensor/mchp_tach_xec/tach_mchp_xec.c
 +++ b/drivers/sensor/mchp_tach_xec/tach_mchp_xec.c
 @@ -1,6 +1,6 @@
@@ -41427,13 +41153,13 @@ index 9ce1e6e554..3d61a6eaa6 100644
   * SPDX-License-Identifier: Apache-2.0
   */
 -- 
-2.17.1
+2.25.1
 
 
-From 2cb0bb4b03164c787c35a036064ee4eb03b56c1a Mon Sep 17 00:00:00 2001
+From 63399c03b71ebdd9993575cb9e740f73dbe59454 Mon Sep 17 00:00:00 2001
 From: Jose Alberto Meza <jose.a.meza.arellano@intel.com>
 Date: Wed, 6 Apr 2022 10:12:56 -0700
-Subject: [PATCH 079/112] soc: arm: microchip: mec172x: Enclose macro in
+Subject: [PATCH 078/111] soc: arm: microchip: mec172x: Enclose macro in
  brackets
 
 Macro should be in brackets.
@@ -41444,7 +41170,7 @@ Signed-off-by: Jose Alberto Meza <jose.a.meza.arellano@intel.com>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/soc/arm/microchip_mec/mec172x/reg/mec172x_espi_iom.h b/soc/arm/microchip_mec/mec172x/reg/mec172x_espi_iom.h
-index d2501723cc..ef6398ff06 100644
+index d2501723c..ef6398ff0 100644
 --- a/soc/arm/microchip_mec/mec172x/reg/mec172x_espi_iom.h
 +++ b/soc/arm/microchip_mec/mec172x/reg/mec172x_espi_iom.h
 @@ -385,8 +385,8 @@
@@ -41459,13 +41185,13 @@ index d2501723cc..ef6398ff06 100644
  #define MCHP_ESPI_FC_CTRL_TAG_POS	4u
  #define MCHP_ESPI_FC_CTRL_TAG_MASK0	0x0fu
 -- 
-2.17.1
+2.25.1
 
 
-From 0a32a5b860ea80fdde202159c4db63246f1ff91a Mon Sep 17 00:00:00 2001
+From a4d53d139b1aa22b452d9dee3059e069a2656ccd Mon Sep 17 00:00:00 2001
 From: Rajavardhan Gundi <rajavardhan.gundi@intel.com>
 Date: Fri, 22 Apr 2022 10:40:56 +0530
-Subject: [PATCH 080/112] drivers: i2c: i2c_mchp_xec: Print ret value for some
+Subject: [PATCH 079/111] drivers: i2c: i2c_mchp_xec: Print ret value for some
  error cases
 
 Checking the return value is very important to understand and
@@ -41477,7 +41203,7 @@ Signed-off-by: Rajavardhan Gundi <rajavardhan.gundi@intel.com>
  1 file changed, 12 insertions(+), 12 deletions(-)
 
 diff --git a/drivers/i2c/i2c_mchp_xec.c b/drivers/i2c/i2c_mchp_xec.c
-index a6aa1c69fb..2c82677e26 100644
+index a6aa1c69f..2c82677e2 100644
 --- a/drivers/i2c/i2c_mchp_xec.c
 +++ b/drivers/i2c/i2c_mchp_xec.c
 @@ -437,8 +437,8 @@ static int i2c_xec_poll_write(const struct device *dev, struct i2c_msg msg,
@@ -41547,13 +41273,13 @@ index a6aa1c69fb..2c82677e26 100644
  		}
  
 -- 
-2.17.1
+2.25.1
 
 
-From 649f56934575c2a98933b225fe2f53367d3f8702 Mon Sep 17 00:00:00 2001
+From 8cf15b1314cfe29aacb2acc232ddeba2da5f33dc Mon Sep 17 00:00:00 2001
 From: Rajavardhan Gundi <rajavardhan.gundi@intel.com>
 Date: Fri, 22 Apr 2022 10:44:08 +0530
-Subject: [PATCH 081/112] drivers: i2c: i2c_mchp_xec: Reset i2c bus when
+Subject: [PATCH 080/111] drivers: i2c: i2c_mchp_xec: Reset i2c bus when
  arbitration is lost
 
 When arbitration is lost, the i2c bus must be reinitialized as
@@ -41565,7 +41291,7 @@ Signed-off-by: Rajavardhan Gundi <rajavardhan.gundi@intel.com>
  1 file changed, 1 insertion(+)
 
 diff --git a/drivers/i2c/i2c_mchp_xec.c b/drivers/i2c/i2c_mchp_xec.c
-index 2c82677e26..223f0d469d 100644
+index 2c82677e2..223f0d469 100644
 --- a/drivers/i2c/i2c_mchp_xec.c
 +++ b/drivers/i2c/i2c_mchp_xec.c
 @@ -266,6 +266,7 @@ static int wait_completion(const struct device *dev)
@@ -41577,14 +41303,13 @@ index 2c82677e26..223f0d469d 100644
  		}
  
 -- 
-2.17.1
+2.25.1
 
 
-From 1bf3e7364619b68b1645583687143a009493650f Mon Sep 17 00:00:00 2001
+From 9218cabc489aa0370c4e049e6a20090e5928a9cf Mon Sep 17 00:00:00 2001
 From: Jose Alberto Meza <jose.a.meza.arellano@intel.com>
 Date: Wed, 20 Apr 2022 14:28:41 -0700
-Subject: [PATCH 082/112] [BACKPORTED] drivers: espi: Correct default eSPI to
- UART mapping
+Subject: [PATCH 081/111] drivers: espi: Correct default eSPI to UART mapping
 
 Correct default mapping for eSPI UART virtual port to SoC UART
 for MEC172x.
@@ -41595,7 +41320,7 @@ Signed-off-by: Jose Alberto Meza <jose.a.meza.arellano@intel.com>
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/espi/Kconfig.xec b/drivers/espi/Kconfig.xec
-index 6ff528068b..39e47e51c7 100644
+index 6ff528068..39e47e51c 100644
 --- a/drivers/espi/Kconfig.xec
 +++ b/drivers/espi/Kconfig.xec
 @@ -31,7 +31,8 @@ config ESPI_PERIPHERAL_UART
@@ -41609,13 +41334,13 @@ index 6ff528068b..39e47e51c7 100644
  	help
  	  This tells the driver to which SoC UART to direct the UART traffic
 -- 
-2.17.1
+2.25.1
 
 
-From 4130dd02106c476ae2006f189ccb9f485ee15882 Mon Sep 17 00:00:00 2001
+From e1a54e9545733680eda43af295e2835725f2c76b Mon Sep 17 00:00:00 2001
 From: Jose Alberto Meza <jose.a.meza.arellano@intel.com>
 Date: Mon, 2 May 2022 16:51:35 -0700
-Subject: [PATCH 083/112] drivers: pinctrl: xec: Avoid sequence that causes
+Subject: [PATCH 082/111] drivers: pinctrl: xec: Avoid sequence that causes
  glitch
 
 Whenever EC bootloader already configured a pins as output and
@@ -41630,7 +41355,7 @@ Signed-off-by: Jose Alberto Meza <jose.a.meza.arellano@intel.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/pinctrl/pinctrl_mchp_xec.c b/drivers/pinctrl/pinctrl_mchp_xec.c
-index 05fece9528..6a348e4daf 100644
+index 05fece952..6a348e4da 100644
 --- a/drivers/pinctrl/pinctrl_mchp_xec.c
 +++ b/drivers/pinctrl/pinctrl_mchp_xec.c
 @@ -74,7 +74,7 @@ static int xec_config_pin(uint32_t portpin, uint32_t conf, uint32_t altf)
@@ -41643,14 +41368,13 @@ index 05fece9528..6a348e4daf 100644
  
  	if (conf & BIT(MCHP_XEC_PIN_LOW_POWER_POS)) {
 -- 
-2.17.1
+2.25.1
 
 
-From 043d30142f6bd093862132890bcd0ed4f8177db7 Mon Sep 17 00:00:00 2001
+From 8ab2505ef7c9f10d0500338a497bb97efd897060 Mon Sep 17 00:00:00 2001
 From: Jay Vasanth <jay.vasanth@microchip.com>
 Date: Thu, 14 Apr 2022 14:54:46 -0400
-Subject: [PATCH 084/112] [BACKPORTED] drivers: ps2: Standarize device tree and
- structure
+Subject: [PATCH 083/111] drivers: ps2: Standarize device tree and structure
 
 Standardize PS2 device tree properties. Standardize device
 structure usage. Abstract GIRQ and PCR register access.
@@ -41669,7 +41393,7 @@ Signed-off-by: Jay Vasanth <jay.vasanth@microchip.com>
  9 files changed, 141 insertions(+), 155 deletions(-)
 
 diff --git a/boards/arm/mec1501modular_assy6885/Kconfig.defconfig b/boards/arm/mec1501modular_assy6885/Kconfig.defconfig
-index 55197a750d..0bf8ab2a98 100644
+index 55197a750..0bf8ab2a9 100644
 --- a/boards/arm/mec1501modular_assy6885/Kconfig.defconfig
 +++ b/boards/arm/mec1501modular_assy6885/Kconfig.defconfig
 @@ -39,16 +39,6 @@ config SYS_CLOCK_TICKS_PER_SEC
@@ -41690,7 +41414,7 @@ index 55197a750d..0bf8ab2a98 100644
  	default y
  	depends on SENSOR
 diff --git a/boards/arm/mec1501modular_assy6885/pinmux.c b/boards/arm/mec1501modular_assy6885/pinmux.c
-index 63458da112..49fba59098 100644
+index 63458da11..49fba5909 100644
 --- a/boards/arm/mec1501modular_assy6885/pinmux.c
 +++ b/boards/arm/mec1501modular_assy6885/pinmux.c
 @@ -280,7 +280,7 @@ static int board_pinmux_init(const struct device *dev)
@@ -41712,7 +41436,7 @@ index 63458da112..49fba59098 100644
  	mchp_pcr_periph_slp_ctrl(PCR_PS2_1, MCHP_PCR_SLEEP_DIS);
  	pinmux_pin_set(portd, MCHP_GPIO_154, MCHP_GPIO_CTRL_MUX_F2 |
 diff --git a/boards/arm/mec15xxevb_assy6853/Kconfig.defconfig b/boards/arm/mec15xxevb_assy6853/Kconfig.defconfig
-index b977d30645..f62160c879 100644
+index b977d3064..f62160c87 100644
 --- a/boards/arm/mec15xxevb_assy6853/Kconfig.defconfig
 +++ b/boards/arm/mec15xxevb_assy6853/Kconfig.defconfig
 @@ -39,16 +39,6 @@ config SYS_CLOCK_TICKS_PER_SEC
@@ -41733,7 +41457,7 @@ index b977d30645..f62160c879 100644
  
  config SPI_XEC_QMSPI
 diff --git a/boards/arm/mec15xxevb_assy6853/pinmux.c b/boards/arm/mec15xxevb_assy6853/pinmux.c
-index 07e2703f1c..366cd14220 100644
+index 07e2703f1..366cd1422 100644
 --- a/boards/arm/mec15xxevb_assy6853/pinmux.c
 +++ b/boards/arm/mec15xxevb_assy6853/pinmux.c
 @@ -270,7 +270,7 @@ static int board_pinmux_init(const struct device *dev)
@@ -41755,7 +41479,7 @@ index 07e2703f1c..366cd14220 100644
  	mchp_pcr_periph_slp_ctrl(PCR_PS2_1, MCHP_PCR_SLEEP_DIS);
  	pinmux_pin_set(portd, MCHP_GPIO_154, MCHP_GPIO_CTRL_MUX_F2 |
 diff --git a/drivers/ps2/Kconfig.xec b/drivers/ps2/Kconfig.xec
-index cc297a7fcb..0ace21a746 100644
+index cc297a7fc..0ace21a74 100644
 --- a/drivers/ps2/Kconfig.xec
 +++ b/drivers/ps2/Kconfig.xec
 @@ -3,23 +3,9 @@
@@ -41784,7 +41508,7 @@ index cc297a7fcb..0ace21a746 100644
 -
 -endif # PS2_XEC
 diff --git a/drivers/ps2/ps2_mchp_xec.c b/drivers/ps2/ps2_mchp_xec.c
-index c316ce2ce1..8f83941417 100644
+index c316ce2ce..8f8394141 100644
 --- a/drivers/ps2/ps2_mchp_xec.c
 +++ b/drivers/ps2/ps2_mchp_xec.c
 @@ -1,11 +1,13 @@
@@ -42138,7 +41862,7 @@ index c316ce2ce1..8f83941417 100644
 +
 +DT_INST_FOREACH_STATUS_OKAY(PS2_XEC_DEVICE)
 diff --git a/dts/arm/microchip/mec1501hsz.dtsi b/dts/arm/microchip/mec1501hsz.dtsi
-index 68b5a3a0a7..3d8be998b9 100644
+index 68b5a3a0a..3d8be998b 100644
 --- a/dts/arm/microchip/mec1501hsz.dtsi
 +++ b/dts/arm/microchip/mec1501hsz.dtsi
 @@ -320,23 +320,23 @@
@@ -42170,7 +41894,7 @@ index 68b5a3a0a7..3d8be998b9 100644
  		pwm0: pwm@40005800 {
  			compatible = "microchip,xec-pwm";
 diff --git a/dts/bindings/ps2/microchip,xec-ps2.yaml b/dts/bindings/ps2/microchip,xec-ps2.yaml
-index ec1c50613c..940343655f 100644
+index ec1c50613..940343655 100644
 --- a/dts/bindings/ps2/microchip,xec-ps2.yaml
 +++ b/dts/bindings/ps2/microchip,xec-ps2.yaml
 @@ -14,12 +14,22 @@ properties:
@@ -42203,7 +41927,7 @@ index ec1c50613c..940343655f 100644
 +    - regidx
 +    - bitpos
 diff --git a/soc/arm/microchip_mec/mec172x/Kconfig.defconfig.series b/soc/arm/microchip_mec/mec172x/Kconfig.defconfig.series
-index 1a34351051..79448b5c86 100644
+index 1a3435105..79448b5c8 100644
 --- a/soc/arm/microchip_mec/mec172x/Kconfig.defconfig.series
 +++ b/soc/arm/microchip_mec/mec172x/Kconfig.defconfig.series
 @@ -41,4 +41,8 @@ config MCHP_ECIA_XEC
@@ -42216,14 +41940,13 @@ index 1a34351051..79448b5c86 100644
 +
  endif # SOC_SERIES_MEC172X
 -- 
-2.17.1
+2.25.1
 
 
-From 9eba1fd1255a5c13a788bcfbb804c7a55df1d151 Mon Sep 17 00:00:00 2001
+From 7a1ed9508979954151ff4a86d93a31477891e30f Mon Sep 17 00:00:00 2001
 From: Jay Vasanth <jay.vasanth@microchip.com>
 Date: Fri, 8 Apr 2022 18:03:26 -0400
-Subject: [PATCH 085/112] [BACKPORTED] drivers: ps2: Microchip XEC PS2 add
- MEC172x support
+Subject: [PATCH 084/111] drivers: ps2: Microchip XEC PS2 add MEC172x support
 
 Update the Microchip XEC PS2 driver to support MEC172x.
 NOTE: MEC15xx has two PS2 controllers and
@@ -42237,7 +41960,7 @@ Signed-off-by: Jay Vasanth <jay.vasanth@microchip.com>
  3 files changed, 30 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/ps2/Kconfig.xec b/drivers/ps2/Kconfig.xec
-index 0ace21a746..89a23b97da 100644
+index 0ace21a74..89a23b97d 100644
 --- a/drivers/ps2/Kconfig.xec
 +++ b/drivers/ps2/Kconfig.xec
 @@ -8,4 +8,5 @@ config PS2_XEC
@@ -42248,7 +41971,7 @@ index 0ace21a746..89a23b97da 100644
 +	  depends on the KBC 8042 keyboard controller. Note, MEC15xx
 +	  series has two controllers and MEC172x series has one.
 diff --git a/drivers/ps2/ps2_mchp_xec.c b/drivers/ps2/ps2_mchp_xec.c
-index 8f83941417..5a0bef51d0 100644
+index 8f8394141..5a0bef51d 100644
 --- a/drivers/ps2/ps2_mchp_xec.c
 +++ b/drivers/ps2/ps2_mchp_xec.c
 @@ -10,6 +10,10 @@
@@ -42300,7 +42023,7 @@ index 8f83941417..5a0bef51d0 100644
  static int ps2_xec_configure(const struct device *dev,
  			     ps2_callback_t callback_isr)
 diff --git a/dts/arm/microchip/mec172xnsz.dtsi b/dts/arm/microchip/mec172xnsz.dtsi
-index f2c9e7a389..8d20229094 100644
+index f2c9e7a38..8d2022909 100644
 --- a/dts/arm/microchip/mec172xnsz.dtsi
 +++ b/dts/arm/microchip/mec172xnsz.dtsi
 @@ -575,8 +575,8 @@
@@ -42314,14 +42037,14 @@ index f2c9e7a389..8d20229094 100644
  			interrupts = <100 1>;
  			girqs = <18 10>;
 -- 
-2.17.1
+2.25.1
 
 
-From d817816c60ed570b38e69fbf4594b75ba1a8ad82 Mon Sep 17 00:00:00 2001
+From 99fde12aa214b30eb32cb3e35fd5c19aa17efcac Mon Sep 17 00:00:00 2001
 From: Jay Vasanth <jay.vasanth@microchip.com>
 Date: Mon, 11 Apr 2022 16:23:20 -0400
-Subject: [PATCH 086/112] [BACKPORTED] drivers: ps2: Microchip XEC PS2 driver
- add PINCTRL support
+Subject: [PATCH 085/111] drivers: ps2: Microchip XEC PS2 driver add PINCTRL
+ support
 
 Add optional PINCTRL support to the Microchip XEC PS2 driver
 shared between MEC15xx and MEC172x families.
@@ -42334,7 +42057,7 @@ Signed-off-by: Jay Vasanth <jay.vasanth@microchip.com>
  3 files changed, 40 insertions(+), 1 deletion(-)
 
 diff --git a/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts b/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts
-index 3fe63c9fac..ed774ad269 100644
+index 3fe63c9fa..ed774ad26 100644
 --- a/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts
 +++ b/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts
 @@ -245,3 +245,9 @@
@@ -42348,7 +42071,7 @@ index 3fe63c9fac..ed774ad269 100644
 +	pinctrl-names = "default";
 +};
 diff --git a/drivers/ps2/ps2_mchp_xec.c b/drivers/ps2/ps2_mchp_xec.c
-index 5a0bef51d0..bcf7a2d529 100644
+index 5a0bef51d..bcf7a2d52 100644
 --- a/drivers/ps2/ps2_mchp_xec.c
 +++ b/drivers/ps2/ps2_mchp_xec.c
 @@ -14,6 +14,9 @@
@@ -42428,7 +42151,7 @@ index 5a0bef51d0..bcf7a2d529 100644
  									\
  	DEVICE_DT_INST_DEFINE(i, &ps2_xec_init,				\
 diff --git a/dts/bindings/ps2/microchip,xec-ps2.yaml b/dts/bindings/ps2/microchip,xec-ps2.yaml
-index 940343655f..75bf61a304 100644
+index 940343655..75bf61a30 100644
 --- a/dts/bindings/ps2/microchip,xec-ps2.yaml
 +++ b/dts/bindings/ps2/microchip,xec-ps2.yaml
 @@ -5,7 +5,7 @@ description: Microchip XEC PS/2 controller
@@ -42441,14 +42164,14 @@ index 940343655f..75bf61a304 100644
  properties:
      reg:
 -- 
-2.17.1
+2.25.1
 
 
-From 9f04f08cdbc4f77016f3286a5b23213478bb6e09 Mon Sep 17 00:00:00 2001
+From 9a6631de115100e9707680900038820d5434b095 Mon Sep 17 00:00:00 2001
 From: Jay Vasanth <jay.vasanth@microchip.com>
 Date: Thu, 14 Apr 2022 15:22:30 -0400
-Subject: [PATCH 087/112] [BACKPORTED] boards: arm: mec172xevb_assy6906:
- Include limited drivers
+Subject: [PATCH 086/111] boards: arm: mec172xevb_assy6906: Include limited
+ drivers
 
 Include only required drivers for hello world application
 
@@ -42458,7 +42181,7 @@ Signed-off-by: Jay Vasanth <jay.vasanth@microchip.com>
  1 file changed, 5 deletions(-)
 
 diff --git a/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906_defconfig b/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906_defconfig
-index a0a545e136..63e6a6be73 100644
+index a0a545e13..63e6a6be7 100644
 --- a/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906_defconfig
 +++ b/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906_defconfig
 @@ -15,8 +15,3 @@ CONFIG_PINCTRL=y
@@ -42471,14 +42194,13 @@ index a0a545e136..63e6a6be73 100644
 -CONFIG_SPI=y
 -CONFIG_SPI_ASYNC=y
 -- 
-2.17.1
+2.25.1
 
 
-From 31da9a17d41324b73fd383897a1a3f2cf1196cce Mon Sep 17 00:00:00 2001
+From b472f60aa1d7f0b200527757e7c3435506f98a01 Mon Sep 17 00:00:00 2001
 From: Jay Vasanth <jay.vasanth@microchip.com>
 Date: Tue, 19 Apr 2022 17:30:17 -0400
-Subject: [PATCH 088/112] [BACKPORTED] boards: mec172xevb: Fix cmake no sources
- warning
+Subject: [PATCH 087/111] boards: mec172xevb: Fix cmake no sources warning
 
 Microchip MEC172x EVB no longer has any C files in board
 folder. Remove the cmake library rule as it it causing
@@ -42490,7 +42212,7 @@ Signed-off-by: Jay Vasanth <jay.vasanth@microchip.com>
  1 file changed, 2 deletions(-)
 
 diff --git a/boards/arm/mec172xevb_assy6906/CMakeLists.txt b/boards/arm/mec172xevb_assy6906/CMakeLists.txt
-index b220461649..2f594e415d 100644
+index b22046164..2f594e415 100644
 --- a/boards/arm/mec172xevb_assy6906/CMakeLists.txt
 +++ b/boards/arm/mec172xevb_assy6906/CMakeLists.txt
 @@ -4,8 +4,6 @@
@@ -42503,14 +42225,14 @@ index b220461649..2f594e415d 100644
    # Grab it from environment variable if defined
    set(MEC172X_SPI_GEN $ENV{MEC172X_SPI_GEN})
 -- 
-2.17.1
+2.25.1
 
 
-From 2b22212a6bf4cb790b94061a50a298e627707899 Mon Sep 17 00:00:00 2001
+From 547eb82354ad54b8cce51f26e520a1e9289e01da Mon Sep 17 00:00:00 2001
 From: Jay Vasanth <jay.vasanth@microchip.com>
 Date: Tue, 19 Apr 2022 17:55:11 -0400
-Subject: [PATCH 089/112] [BACKPORTED] drivers: clock-control: Microchip
- MEC172x adjust clock based on OTP
+Subject: [PATCH 088/111] drivers: clock-control: Microchip MEC172x adjust
+ clock based on OTP
 
 Microchip MEC172x CPU and fast peripheral (QMSPI and PK) are
 clock source is based upon an OTP setting. Add logic to adjust
@@ -42523,7 +42245,7 @@ Signed-off-by: Jay Vasanth <jay.vasanth@microchip.com>
  1 file changed, 10 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/clock_control/clock_control_mchp_xec.c b/drivers/clock_control/clock_control_mchp_xec.c
-index 851130fb78..fbbf37513f 100644
+index 851130fb7..fbbf37513 100644
 --- a/drivers/clock_control/clock_control_mchp_xec.c
 +++ b/drivers/clock_control/clock_control_mchp_xec.c
 @@ -559,11 +559,19 @@ static int xec_clock_control_get_subsys_rate(const struct device *dev,
@@ -42549,13 +42271,13 @@ index 851130fb78..fbbf37513f 100644
  	case MCHP_XEC_PCR_CLK_BUS:
  	case MCHP_XEC_PCR_CLK_PERIPH:
 -- 
-2.17.1
+2.25.1
 
 
-From 01a5acbdb41fda04512ce75fe3a78988f6770ed7 Mon Sep 17 00:00:00 2001
+From 2df803d52c60d6843df5786594faeb63d208c51b Mon Sep 17 00:00:00 2001
 From: Jay Vasanth <jay.vasanth@microchip.com>
 Date: Tue, 19 Apr 2022 18:13:59 -0400
-Subject: [PATCH 090/112] [BACKPORTED] drivers: SPI: MEC172x QMSPI clock fix
+Subject: [PATCH 089/111] drivers: SPI: MEC172x QMSPI clock fix
 
 Microchip MEC172x QMSPI expanded its clock divider register
 field from 8 to 16 bits. QMSPI source clock is on the fast
@@ -42570,7 +42292,7 @@ Signed-off-by: Jay Vasanth <jay.vasanth@microchip.com>
  3 files changed, 46 insertions(+), 24 deletions(-)
 
 diff --git a/drivers/spi/spi_xec_qmspi_ldma.c b/drivers/spi/spi_xec_qmspi_ldma.c
-index e601b6c04c..c3493a55a0 100644
+index e601b6c04..c3493a55a 100644
 --- a/drivers/spi/spi_xec_qmspi_ldma.c
 +++ b/drivers/spi/spi_xec_qmspi_ldma.c
 @@ -29,6 +29,8 @@ LOG_MODULE_REGISTER(spi_xec, CONFIG_SPI_LOG_LEVEL);
@@ -42689,7 +42411,7 @@ index e601b6c04c..c3493a55a0 100644
  	mchp_xec_ecia_girq_src_clr(cfg->girq, cfg->girq_pos);
  
 diff --git a/dts/arm/microchip/mec172xnsz.dtsi b/dts/arm/microchip/mec172xnsz.dtsi
-index 8d20229094..dd754905f2 100644
+index 8d2022909..dd754905f 100644
 --- a/dts/arm/microchip/mec172xnsz.dtsi
 +++ b/dts/arm/microchip/mec172xnsz.dtsi
 @@ -755,6 +755,7 @@
@@ -42701,7 +42423,7 @@ index 8d20229094..dd754905f2 100644
  			label = "SPI_0";
  			lines = <1>;
 diff --git a/soc/arm/microchip_mec/mec172x/reg/mec172x_qspi.h b/soc/arm/microchip_mec/mec172x/reg/mec172x_qspi.h
-index cb2be6eed4..496c0f5238 100644
+index cb2be6eed..496c0f523 100644
 --- a/soc/arm/microchip_mec/mec172x/reg/mec172x_qspi.h
 +++ b/soc/arm/microchip_mec/mec172x/reg/mec172x_qspi.h
 @@ -168,8 +168,8 @@
@@ -42724,14 +42446,14 @@ index cb2be6eed4..496c0f5238 100644
  #define MCHP_QMSPI_C_NO_CLOSE		0u
  #define MCHP_QMSPI_C_CLOSE		BIT(MCHP_QMSPI_C_CLOSE_POS)
 -- 
-2.17.1
+2.25.1
 
 
-From 7ed7cb52c0e3d4dc706b428591799b07c627fda3 Mon Sep 17 00:00:00 2001
+From 0a9128d5090c54c75c34c30cfeec8fbed8164431 Mon Sep 17 00:00:00 2001
 From: Jay Vasanth <jay.vasanth@microchip.com>
 Date: Tue, 19 Apr 2022 18:14:46 -0400
-Subject: [PATCH 091/112] [BACKPORTED] drivers: espi: Microchip MEC172x child
- host device interrupt priorities
+Subject: [PATCH 090/111] drivers: espi: Microchip MEC172x child host device
+ interrupt priorities
 
 Set default interrupt priority to 3 for all Microchip MEC172x eSPI
 host child devices except the UART's which are set to 1.
@@ -42742,7 +42464,7 @@ Signed-off-by: Jay Vasanth <jay.vasanth@microchip.com>
  1 file changed, 7 insertions(+), 7 deletions(-)
 
 diff --git a/dts/arm/microchip/mec172xnsz.dtsi b/dts/arm/microchip/mec172xnsz.dtsi
-index dd754905f2..43a4efd799 100644
+index dd754905f..43a4efd79 100644
 --- a/dts/arm/microchip/mec172xnsz.dtsi
 +++ b/dts/arm/microchip/mec172xnsz.dtsi
 @@ -901,7 +901,7 @@
@@ -42809,14 +42531,13 @@ index dd754905f2..43a4efd799 100644
  					  MCHP_XEC_ECIA(21, 9, 13, 120) >;
  				pcrs = <2 18>;
 -- 
-2.17.1
+2.25.1
 
 
-From 473c3473b3272c1e9ab695da63328bf9538e648e Mon Sep 17 00:00:00 2001
+From f79023412b13c57fa3f5300306a72ea4c2518341 Mon Sep 17 00:00:00 2001
 From: Jay Vasanth <jay.vasanth@microchip.com>
 Date: Tue, 19 Apr 2022 18:16:07 -0400
-Subject: [PATCH 092/112] [BACKPORTED] soc: microchip_mec: Prepare for MEC172x
- SAF version 2
+Subject: [PATCH 091/111] soc: microchip_mec: Prepare for MEC172x SAF version 2
 
 Microchip MEC172x eSPI SAF has significant hardware changes
 requiring a new SAF configuration structure. In preparation
@@ -42833,7 +42554,7 @@ Signed-off-by: Jay Vasanth <jay.vasanth@microchip.com>
  rename soc/arm/microchip_mec/{common/soc_espi_saf.h => mec1501/soc_espi_saf_v1.h} (98%)
 
 diff --git a/soc/arm/microchip_mec/mec1501/soc.h b/soc/arm/microchip_mec/mec1501/soc.h
-index dd48cc15ca..b5c8e138e2 100644
+index dd48cc15c..b5c8e138e 100644
 --- a/soc/arm/microchip_mec/mec1501/soc.h
 +++ b/soc/arm/microchip_mec/mec1501/soc.h
 @@ -17,7 +17,7 @@
@@ -42849,7 +42570,7 @@ diff --git a/soc/arm/microchip_mec/common/soc_espi_saf.h b/soc/arm/microchip_mec
 similarity index 98%
 rename from soc/arm/microchip_mec/common/soc_espi_saf.h
 rename to soc/arm/microchip_mec/mec1501/soc_espi_saf_v1.h
-index 7695904cc4..5e0b846969 100644
+index 7695904cc..5e0b84696 100644
 --- a/soc/arm/microchip_mec/common/soc_espi_saf.h
 +++ b/soc/arm/microchip_mec/mec1501/soc_espi_saf_v1.h
 @@ -265,9 +265,9 @@
@@ -42866,7 +42587,7 @@ index 7695904cc4..5e0b846969 100644
  #define MCHP_W25Q256_POLL2_MASK 0xff7fU
  
 diff --git a/soc/arm/microchip_mec/mec172x/soc.h b/soc/arm/microchip_mec/mec172x/soc.h
-index 1ee8a991d1..b5d6b24fe6 100644
+index 1ee8a991d..b5d6b24fe 100644
 --- a/soc/arm/microchip_mec/mec172x/soc.h
 +++ b/soc/arm/microchip_mec/mec172x/soc.h
 @@ -281,7 +281,6 @@ typedef enum {
@@ -42878,14 +42599,14 @@ index 1ee8a991d1..b5d6b24fe6 100644
  
  #endif
 -- 
-2.17.1
+2.25.1
 
 
-From 5140e786fd071a52f0e840a783fe1e59555193b1 Mon Sep 17 00:00:00 2001
+From ea3d7267d3a388108f67175aaba121a952d8ac4f Mon Sep 17 00:00:00 2001
 From: Jay Vasanth <jay.vasanth@microchip.com>
 Date: Tue, 19 Apr 2022 18:37:17 -0400
-Subject: [PATCH 093/112] [BACKPORTED] drivers: espi_saf: Add Microchip MEC172x
- eSPI SAF version 2 driver
+Subject: [PATCH 092/111] drivers: espi_saf: Add Microchip MEC172x eSPI SAF
+ version 2 driver
 
 Microchip MEC172x has a modified eSPI SAF hardware implementation.
 Hardware changes include multiple clock dividers for each SPI
@@ -42915,7 +42636,7 @@ Signed-off-by: Jose Alberto Meza <jose.a.meza.arellano@intel.com>
  create mode 100644 soc/arm/microchip_mec/mec172x/soc_espi_saf_v2.h
 
 diff --git a/drivers/espi/CMakeLists.txt b/drivers/espi/CMakeLists.txt
-index 5ba46d2615..0200f9e9d7 100644
+index 5ba46d261..0200f9e9d 100644
 --- a/drivers/espi/CMakeLists.txt
 +++ b/drivers/espi/CMakeLists.txt
 @@ -7,6 +7,7 @@ zephyr_library_sources_ifdef(CONFIG_ESPI_NPCX		espi_npcx.c)
@@ -42928,7 +42649,7 @@ index 5ba46d2615..0200f9e9d7 100644
  zephyr_library_sources_ifdef(CONFIG_ESPI_XEC_V2		espi_mchp_xec_host_v2.c)
 +zephyr_library_sources_ifdef(CONFIG_ESPI_SAF_XEC_V2	espi_saf_mchp_xec_v2.c)
 diff --git a/drivers/espi/Kconfig b/drivers/espi/Kconfig
-index 6a8c2ecac9..eadb642d68 100644
+index 6a8c2ecac..eadb642d6 100644
 --- a/drivers/espi/Kconfig
 +++ b/drivers/espi/Kconfig
 @@ -12,8 +12,6 @@ if ESPI
@@ -42961,7 +42682,7 @@ index 6a8c2ecac9..eadb642d68 100644
 +
  endif # ESPI
 diff --git a/drivers/espi/Kconfig.xec b/drivers/espi/Kconfig.xec
-index 39e47e51c7..ebe5ebb54c 100644
+index 39e47e51c..ebe5ebb54 100644
 --- a/drivers/espi/Kconfig.xec
 +++ b/drivers/espi/Kconfig.xec
 @@ -9,7 +9,13 @@ config ESPI_XEC
@@ -43008,7 +42729,7 @@ index 39e47e51c7..ebe5ebb54c 100644
  endif #ESPI_XEC
 diff --git a/drivers/espi/Kconfig.xec_v2 b/drivers/espi/Kconfig.xec_v2
 deleted file mode 100644
-index 351f90c852..0000000000
+index 351f90c85..000000000
 --- a/drivers/espi/Kconfig.xec_v2
 +++ /dev/null
 @@ -1,148 +0,0 @@
@@ -43162,7 +42883,7 @@ index 351f90c852..0000000000
 -endif #ESPI_XEC_V2
 diff --git a/drivers/espi/espi_saf_mchp_xec_v2.c b/drivers/espi/espi_saf_mchp_xec_v2.c
 new file mode 100644
-index 0000000000..6b75ace772
+index 000000000..6b75ace77
 --- /dev/null
 +++ b/drivers/espi/espi_saf_mchp_xec_v2.c
 @@ -0,0 +1,1164 @@
@@ -44331,7 +44052,7 @@ index 0000000000..6b75ace772
 +	return 0;
 +}
 diff --git a/dts/arm/microchip/mec172xnsz.dtsi b/dts/arm/microchip/mec172xnsz.dtsi
-index 43a4efd799..bc94dfb076 100644
+index 43a4efd79..bc94dfb07 100644
 --- a/dts/arm/microchip/mec172xnsz.dtsi
 +++ b/dts/arm/microchip/mec172xnsz.dtsi
 @@ -874,12 +874,17 @@
@@ -44382,7 +44103,7 @@ index 43a4efd799..bc94dfb076 100644
  				reg = <0x400f0000 0x200>;
 diff --git a/dts/bindings/espi/microchip,xec-espi-saf-v2.yaml b/dts/bindings/espi/microchip,xec-espi-saf-v2.yaml
 new file mode 100644
-index 0000000000..84e41cc13d
+index 000000000..84e41cc13
 --- /dev/null
 +++ b/dts/bindings/espi/microchip,xec-espi-saf-v2.yaml
 @@ -0,0 +1,64 @@
@@ -44451,7 +44172,7 @@ index 0000000000..84e41cc13d
 +    - regidx
 +    - bitpos
 diff --git a/include/drivers/espi.h b/include/drivers/espi.h
-index 4839c2473a..311f48291e 100644
+index 4839c2473..311f48291 100644
 --- a/include/drivers/espi.h
 +++ b/include/drivers/espi.h
 @@ -113,6 +113,7 @@ enum espi_bus_event {
@@ -44463,7 +44184,7 @@ index 4839c2473a..311f48291e 100644
  
  /**
 diff --git a/soc/arm/microchip_mec/mec1501/Kconfig.defconfig.mec1501hsz b/soc/arm/microchip_mec/mec1501/Kconfig.defconfig.mec1501hsz
-index 02ff26b9d9..afe266125e 100644
+index 02ff26b9d..afe266125 100644
 --- a/soc/arm/microchip_mec/mec1501/Kconfig.defconfig.mec1501hsz
 +++ b/soc/arm/microchip_mec/mec1501/Kconfig.defconfig.mec1501hsz
 @@ -35,6 +35,10 @@ config ESPI_XEC
@@ -44478,7 +44199,7 @@ index 02ff26b9d9..afe266125e 100644
  	default y
  	depends on COUNTER
 diff --git a/soc/arm/microchip_mec/mec172x/Kconfig.defconfig.mec172xnsz b/soc/arm/microchip_mec/mec172x/Kconfig.defconfig.mec172xnsz
-index 75c3717f18..5ca98bd3c1 100644
+index 75c3717f1..5ca98bd3c 100644
 --- a/soc/arm/microchip_mec/mec172x/Kconfig.defconfig.mec172xnsz
 +++ b/soc/arm/microchip_mec/mec172x/Kconfig.defconfig.mec172xnsz
 @@ -39,6 +39,10 @@ config ESPI_XEC_V2
@@ -44493,7 +44214,7 @@ index 75c3717f18..5ca98bd3c1 100644
  	default y
  	depends on SPI
 diff --git a/soc/arm/microchip_mec/mec172x/reg/mec172x_espi_saf.h b/soc/arm/microchip_mec/mec172x/reg/mec172x_espi_saf.h
-index 8c7db2d633..79dec74a30 100644
+index 8c7db2d63..79dec74a3 100644
 --- a/soc/arm/microchip_mec/mec172x/reg/mec172x_espi_saf.h
 +++ b/soc/arm/microchip_mec/mec172x/reg/mec172x_espi_saf.h
 @@ -36,30 +36,40 @@
@@ -44813,7 +44534,7 @@ index 8c7db2d633..79dec74a30 100644
  
  struct mchp_espi_saf_comm { /* @ 0x40071000 */
 diff --git a/soc/arm/microchip_mec/mec172x/reg/mec172x_qspi.h b/soc/arm/microchip_mec/mec172x/reg/mec172x_qspi.h
-index 496c0f5238..fa04a2da01 100644
+index 496c0f523..fa04a2da0 100644
 --- a/soc/arm/microchip_mec/mec172x/reg/mec172x_qspi.h
 +++ b/soc/arm/microchip_mec/mec172x/reg/mec172x_qspi.h
 @@ -188,6 +188,9 @@
@@ -44837,7 +44558,7 @@ index 496c0f5238..fa04a2da01 100644
  #define MCHP_QMSPI_C_CLOSE_POS		9u
  #define MCHP_QMSPI_C_NO_CLOSE		0u
 diff --git a/soc/arm/microchip_mec/mec172x/soc.h b/soc/arm/microchip_mec/mec172x/soc.h
-index b5d6b24fe6..940ac10369 100644
+index b5d6b24fe..940ac1036 100644
 --- a/soc/arm/microchip_mec/mec172x/soc.h
 +++ b/soc/arm/microchip_mec/mec172x/soc.h
 @@ -283,6 +283,9 @@ typedef enum {
@@ -44852,7 +44573,7 @@ index b5d6b24fe6..940ac10369 100644
  #endif
 diff --git a/soc/arm/microchip_mec/mec172x/soc_espi_saf_v2.h b/soc/arm/microchip_mec/mec172x/soc_espi_saf_v2.h
 new file mode 100644
-index 0000000000..d4fa144aec
+index 000000000..d4fa144ae
 --- /dev/null
 +++ b/soc/arm/microchip_mec/mec172x/soc_espi_saf_v2.h
 @@ -0,0 +1,516 @@
@@ -45373,13 +45094,13 @@ index 0000000000..d4fa144aec
 +
 +#endif /* _SOC_ESPI_SAF_H_ */
 -- 
-2.17.1
+2.25.1
 
 
-From fe13b044382574bf4bb32323b9543003e79108ee Mon Sep 17 00:00:00 2001
+From 4b38994d88f5c87e139b4bd97da748c70dc2cc64 Mon Sep 17 00:00:00 2001
 From: Jose Alberto Meza <jose.a.meza.arellano@intel.com>
 Date: Wed, 4 May 2022 17:03:21 -0700
-Subject: [PATCH 094/112] drivers: espi: saf: xec: Adjust MEC172x SAF DT macro
+Subject: [PATCH 093/111] drivers: espi: saf: xec: Adjust MEC172x SAF DT macro
  to work at v2.7
 
 Certain DT macros only exist in Zephyr 3.0 and beyond,
@@ -45391,7 +45112,7 @@ Signed-off-by: Jose Alberto Meza <jose.a.meza.arellano@intel.com>
  1 file changed, 5 insertions(+)
 
 diff --git a/drivers/espi/espi_saf_mchp_xec_v2.c b/drivers/espi/espi_saf_mchp_xec_v2.c
-index 6b75ace772..7ab98ac422 100644
+index 6b75ace77..7ab98ac42 100644
 --- a/drivers/espi/espi_saf_mchp_xec_v2.c
 +++ b/drivers/espi/espi_saf_mchp_xec_v2.c
 @@ -1089,6 +1089,11 @@ static const struct espi_xec_irq_info espi_saf_xec_irq_info_0[] = {
@@ -45407,13 +45128,13 @@ index 6b75ace772..7ab98ac422 100644
  	.saf_base = (struct mchp_espi_saf * const)(DT_INST_REG_ADDR_BY_IDX(0, 0)),
  	.qmspi_base = (struct qmspi_regs * const)(DT_INST_REG_ADDR_BY_IDX(0, 1)),
 -- 
-2.17.1
+2.25.1
 
 
-From d4c6094add904ef2d09bd7da2a8e19be73a4cf66 Mon Sep 17 00:00:00 2001
+From 6d986d905056917ca5db23db395b72f7b29abdee Mon Sep 17 00:00:00 2001
 From: Jose Alberto Meza <jose.a.meza.arellano@intel.com>
 Date: Thu, 14 Oct 2021 15:38:06 -0700
-Subject: [PATCH 095/112] drivers: espi: Workaround to allow Dual SPI mode for
+Subject: [PATCH 094/111] drivers: espi: Workaround to allow Dual SPI mode for
  SAF
 
 Change continous read descriptor sequence to account for
@@ -45429,7 +45150,7 @@ Signed-off-by: Jose Alberto Meza <jose.a.meza.arellano@intel.com>
  4 files changed, 51 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/espi/espi_saf_mchp_xec.c b/drivers/espi/espi_saf_mchp_xec.c
-index 950340f4ae..3fded10677 100644
+index 950340f4a..3fded1067 100644
 --- a/drivers/espi/espi_saf_mchp_xec.c
 +++ b/drivers/espi/espi_saf_mchp_xec.c
 @@ -237,7 +237,7 @@ static int saf_qmspi_init(const struct espi_saf_xec_config *xcfg,
@@ -45473,7 +45194,7 @@ index 950340f4ae..3fded10677 100644
  
  	mchp_saf_poll2_mask_wr(regs, cs, fcfg->poll2_mask);
 diff --git a/drivers/espi/espi_saf_mchp_xec_v2.c b/drivers/espi/espi_saf_mchp_xec_v2.c
-index 7ab98ac422..5a8d3913c5 100644
+index 7ab98ac42..5a8d3913c 100644
 --- a/drivers/espi/espi_saf_mchp_xec_v2.c
 +++ b/drivers/espi/espi_saf_mchp_xec_v2.c
 @@ -533,6 +533,29 @@ static int saf_flash_cfg(const struct device *dev,
@@ -45507,7 +45228,7 @@ index 7ab98ac422..5a8d3913c5 100644
  
  	mchp_saf_poll2_mask_wr(regs, cs, fcfg->poll2_mask);
 diff --git a/soc/arm/microchip_mec/mec1501/soc_espi_saf_v1.h b/soc/arm/microchip_mec/mec1501/soc_espi_saf_v1.h
-index 5e0b846969..6e4a72c86b 100644
+index 5e0b84696..6e4a72c86 100644
 --- a/soc/arm/microchip_mec/mec1501/soc_espi_saf_v1.h
 +++ b/soc/arm/microchip_mec/mec1501/soc_espi_saf_v1.h
 @@ -404,4 +404,6 @@ struct espi_saf_protection {
@@ -45518,7 +45239,7 @@ index 5e0b846969..6e4a72c86b 100644
 +
  #endif /* _SOC_ESPI_SAF_H_ */
 diff --git a/soc/arm/microchip_mec/mec172x/soc_espi_saf_v2.h b/soc/arm/microchip_mec/mec172x/soc_espi_saf_v2.h
-index d4fa144aec..29498cfa0f 100644
+index d4fa144ae..29498cfa0 100644
 --- a/soc/arm/microchip_mec/mec172x/soc_espi_saf_v2.h
 +++ b/soc/arm/microchip_mec/mec172x/soc_espi_saf_v2.h
 @@ -513,4 +513,6 @@ struct espi_saf_protection {
@@ -45529,13 +45250,13 @@ index d4fa144aec..29498cfa0f 100644
 +
  #endif /* _SOC_ESPI_SAF_H_ */
 -- 
-2.17.1
+2.25.1
 
 
-From 3540e0e17235bf583de319aa3dda3e0440576346 Mon Sep 17 00:00:00 2001
+From e8ba7f5e60c33707c04a8abbb23f609d8953a37f Mon Sep 17 00:00:00 2001
 From: Jose Alberto Meza <jose.a.meza.arellano@intel.com>
 Date: Mon, 2 May 2022 13:24:27 -0700
-Subject: [PATCH 096/112] boards: mec172xmodular: Fix cmake no sources warning
+Subject: [PATCH 095/111] boards: mec172xmodular: Fix cmake no sources warning
 
 Microchip MEC172x no longer has any C files in board folder.
 Remove the cmake library rule as it it causing a build warning
@@ -45547,7 +45268,7 @@ Signed-off-by: Jose Alberto Meza <jose.a.meza.arellano@intel.com>
  1 file changed, 2 deletions(-)
 
 diff --git a/boards/arm/mec172xmodular_assy6930/CMakeLists.txt b/boards/arm/mec172xmodular_assy6930/CMakeLists.txt
-index ed0e3e513d..f6e76b8a60 100644
+index ed0e3e513..f6e76b8a6 100644
 --- a/boards/arm/mec172xmodular_assy6930/CMakeLists.txt
 +++ b/boards/arm/mec172xmodular_assy6930/CMakeLists.txt
 @@ -4,8 +4,6 @@
@@ -45560,13 +45281,13 @@ index ed0e3e513d..f6e76b8a60 100644
  if (NOT DEFINED MEC172X_SPI_GEN)
    set(MEC172X_SPI_GEN $ENV{MEC172X_SPI_GEN})
 -- 
-2.17.1
+2.25.1
 
 
-From 087a487437435d6b2f4714706f89a8e9fa5807aa Mon Sep 17 00:00:00 2001
+From 2bd7dbc9b59f4c86781030c22be8102291e0cf29 Mon Sep 17 00:00:00 2001
 From: Jose Alberto Meza <jose.a.meza.arellano@intel.com>
 Date: Thu, 12 May 2022 12:31:30 -0700
-Subject: [PATCH 097/112] dts: arm: microchip: mec172x: Use consistent name
+Subject: [PATCH 096/111] dts: arm: microchip: mec172x: Use consistent name
  across Microchip SPI HW block
 
 Use consistent name for SPI HW block property so applications
@@ -45578,7 +45299,7 @@ Signed-off-by: Jose Alberto Meza <jose.a.meza.arellano@intel.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/dts/arm/microchip/mec172xnsz.dtsi b/dts/arm/microchip/mec172xnsz.dtsi
-index bc94dfb076..c934cb2060 100644
+index bc94dfb07..c934cb206 100644
 --- a/dts/arm/microchip/mec172xnsz.dtsi
 +++ b/dts/arm/microchip/mec172xnsz.dtsi
 @@ -759,7 +759,7 @@
@@ -45591,13 +45312,13 @@ index bc94dfb076..c934cb2060 100644
  			#size-cells = <0>;
  			status = "disabled";
 -- 
-2.17.1
+2.25.1
 
 
-From df88381f49fdc4567fd420bdd550c7b74a51d8b2 Mon Sep 17 00:00:00 2001
+From 93a5a94065901f42625e6b9e57caa6a1e4db5ce4 Mon Sep 17 00:00:00 2001
 From: Jose Alberto Meza <jose.a.meza.arellano@intel.com>
 Date: Thu, 12 May 2022 12:33:26 -0700
-Subject: [PATCH 098/112] dts: bindings: spi: Use consistent dts names for
+Subject: [PATCH 097/111] dts: bindings: spi: Use consistent dts names for
  mec172x
 
 Use consistent name for SPI HW block property so applications
@@ -45609,7 +45330,7 @@ Signed-off-by: Jose Alberto Meza <jose.a.meza.arellano@intel.com>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/dts/bindings/spi/microchip,xec-qmspi-ldma.yaml b/dts/bindings/spi/microchip,xec-qmspi-ldma.yaml
-index 6410086ece..c58b7ad632 100644
+index 6410086ec..c58b7ad63 100644
 --- a/dts/bindings/spi/microchip,xec-qmspi-ldma.yaml
 +++ b/dts/bindings/spi/microchip,xec-qmspi-ldma.yaml
 @@ -42,7 +42,7 @@ properties:
@@ -45631,13 +45352,13 @@ index 6410086ece..c58b7ad632 100644
        required: false
        description: |
 -- 
-2.17.1
+2.25.1
 
 
-From f36be7c5e51567ea5aa5448daee158ce032377ef Mon Sep 17 00:00:00 2001
+From 06e0816b45c96185b455859f227d19e28ee3db24 Mon Sep 17 00:00:00 2001
 From: Jose Alberto Meza <jose.a.meza.arellano@intel.com>
 Date: Thu, 12 May 2022 12:34:22 -0700
-Subject: [PATCH 099/112] boards: arm: mec172xevb: Update SPI HW block
+Subject: [PATCH 098/111] boards: arm: mec172xevb: Update SPI HW block
  properties
 
 Reflect device tree field name.
@@ -45648,7 +45369,7 @@ Signed-off-by: Jose Alberto Meza <jose.a.meza.arellano@intel.com>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts b/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts
-index ed774ad269..6c5f12f9e5 100644
+index ed774ad26..6c5f12f9e 100644
 --- a/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts
 +++ b/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts
 @@ -194,8 +194,8 @@
@@ -45663,13 +45384,13 @@ index ed774ad269..6c5f12f9e5 100644
  	pinctrl-0 = < &shd_cs0_n_gpio055
  		      &shd_clk_gpio056
 -- 
-2.17.1
+2.25.1
 
 
-From 0192f270ecc8377d2d7f181b6db1d3b1eb952a9f Mon Sep 17 00:00:00 2001
+From 5c1169381939b3613d4825e21e5f4ea5cbcf9c3e Mon Sep 17 00:00:00 2001
 From: Jose Alberto Meza <jose.a.meza.arellano@intel.com>
 Date: Thu, 12 May 2022 12:42:47 -0700
-Subject: [PATCH 100/112] boards: arm: mec172xevb: Update SPI HW block
+Subject: [PATCH 099/111] boards: arm: mec172xevb: Update SPI HW block
  properties
 
 ---
@@ -45677,7 +45398,7 @@ Subject: [PATCH 100/112] boards: arm: mec172xevb: Update SPI HW block
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/boards/arm/mec172xmodular_assy6930/mec172xmodular_assy6930.dts b/boards/arm/mec172xmodular_assy6930/mec172xmodular_assy6930.dts
-index 8e0f6f79bd..cd97eda88c 100644
+index 8e0f6f79b..cd97eda88 100644
 --- a/boards/arm/mec172xmodular_assy6930/mec172xmodular_assy6930.dts
 +++ b/boards/arm/mec172xmodular_assy6930/mec172xmodular_assy6930.dts
 @@ -195,8 +195,8 @@
@@ -45692,13 +45413,13 @@ index 8e0f6f79bd..cd97eda88c 100644
  	pinctrl-0 = < &shd_cs0_n_gpio055
  		      &shd_clk_gpio056
 -- 
-2.17.1
+2.25.1
 
 
-From a4036941cdb23d7d01c8d2d88ca86a01327d644f Mon Sep 17 00:00:00 2001
+From 12ccf3db8ee26c06eaf45d8ddce64ee278f5d73d Mon Sep 17 00:00:00 2001
 From: Jose Alberto Meza <jose.a.meza.arellano@intel.com>
 Date: Thu, 12 May 2022 13:10:48 -0700
-Subject: [PATCH 101/112] drivers: spi: xec: mec172x: Reflect update device
+Subject: [PATCH 100/111] drivers: spi: xec: mec172x: Reflect update device
  tree properties
 
 Propagate update device tree properties.
@@ -45709,7 +45430,7 @@ Signed-off-by: Jose Alberto Meza <jose.a.meza.arellano@intel.com>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/spi/spi_xec_qmspi_ldma.c b/drivers/spi/spi_xec_qmspi_ldma.c
-index c3493a55a0..ec37ab85cd 100644
+index c3493a55a..ec37ab85c 100644
 --- a/drivers/spi/spi_xec_qmspi_ldma.c
 +++ b/drivers/spi/spi_xec_qmspi_ldma.c
 @@ -1208,8 +1208,8 @@ static const struct spi_driver_api spi_qmspi_xec_driver_api = {
@@ -45724,13 +45445,13 @@ index c3493a55a0..ec37ab85cd 100644
  		.irq_config_func = qmspi_xec_irq_config_func_##i,	\
  		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(i),		\
 -- 
-2.17.1
+2.25.1
 
 
-From 14a4a7574d50ad85941e218740b5f69eb851eb40 Mon Sep 17 00:00:00 2001
+From 7799a4cde64820b212e10c96e94d1870a5364a04 Mon Sep 17 00:00:00 2001
 From: Jay Vasanth <jay.vasanth@microchip.com>
 Date: Tue, 3 May 2022 15:11:25 -0400
-Subject: [PATCH 102/112] soc: pm: Microchip MEC172x SoC based power management
+Subject: [PATCH 101/111] soc: pm: Microchip MEC172x SoC based power management
 
 Add support for SoC power management for Microchip MEC172x.
 
@@ -45752,7 +45473,7 @@ Signed-off-by: Jay Vasanth <jay.vasanth@microchip.com>
  create mode 100644 soc/arm/microchip_mec/mec172x/soc_power_debug.h
 
 diff --git a/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts b/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts
-index 6c5f12f9e5..f60aa683dc 100644
+index 6c5f12f9e..f60aa683d 100644
 --- a/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts
 +++ b/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts
 @@ -44,6 +44,20 @@
@@ -45777,7 +45498,7 @@ index 6c5f12f9e5..f60aa683dc 100644
  
  &cpu0 {
 diff --git a/soc/arm/microchip_mec/mec172x/CMakeLists.txt b/soc/arm/microchip_mec/mec172x/CMakeLists.txt
-index 493bd1be0b..47f91773dd 100644
+index 493bd1be0..47f91773d 100644
 --- a/soc/arm/microchip_mec/mec172x/CMakeLists.txt
 +++ b/soc/arm/microchip_mec/mec172x/CMakeLists.txt
 @@ -9,6 +9,13 @@ zephyr_sources(
@@ -45795,7 +45516,7 @@ index 493bd1be0b..47f91773dd 100644
    if(CONFIG_TIMING_FUNCTIONS)
      # Use MEC172x timing calculations only if DWT is not present
 diff --git a/soc/arm/microchip_mec/mec172x/Kconfig.defconfig.series b/soc/arm/microchip_mec/mec172x/Kconfig.defconfig.series
-index 79448b5c86..fc215d9774 100644
+index 79448b5c8..fc215d977 100644
 --- a/soc/arm/microchip_mec/mec172x/Kconfig.defconfig.series
 +++ b/soc/arm/microchip_mec/mec172x/Kconfig.defconfig.series
 @@ -45,4 +45,10 @@ config PS2_XEC
@@ -45810,7 +45531,7 @@ index 79448b5c86..fc215d9774 100644
 +
  endif # SOC_SERIES_MEC172X
 diff --git a/soc/arm/microchip_mec/mec172x/Kconfig.soc b/soc/arm/microchip_mec/mec172x/Kconfig.soc
-index 4b910c154d..d74993b446 100644
+index 4b910c154..d74993b44 100644
 --- a/soc/arm/microchip_mec/mec172x/Kconfig.soc
 +++ b/soc/arm/microchip_mec/mec172x/Kconfig.soc
 @@ -24,3 +24,8 @@ config SOC_MEC172X_PROC_CLK_DIV
@@ -45824,7 +45545,7 @@ index 4b910c154d..d74993b446 100644
 +	  Enables a test clock out pin
 diff --git a/soc/arm/microchip_mec/mec172x/device_power.c b/soc/arm/microchip_mec/mec172x/device_power.c
 new file mode 100644
-index 0000000000..e24b9cf184
+index 000000000..e24b9cf18
 --- /dev/null
 +++ b/soc/arm/microchip_mec/mec172x/device_power.c
 @@ -0,0 +1,384 @@
@@ -46214,7 +45935,7 @@ index 0000000000..e24b9cf184
 +#endif /* DEEP_SLEEP_PERIPH_SAVE_RESTORE */
 diff --git a/soc/arm/microchip_mec/mec172x/device_power.h b/soc/arm/microchip_mec/mec172x/device_power.h
 new file mode 100644
-index 0000000000..774bcea819
+index 000000000..774bcea81
 --- /dev/null
 +++ b/soc/arm/microchip_mec/mec172x/device_power.h
 @@ -0,0 +1,101 @@
@@ -46321,7 +46042,7 @@ index 0000000000..774bcea819
 +#endif /* __DEVICE_POWER_H */
 diff --git a/soc/arm/microchip_mec/mec172x/power.c b/soc/arm/microchip_mec/mec172x/power.c
 new file mode 100644
-index 0000000000..7aaf3a8273
+index 000000000..7aaf3a827
 --- /dev/null
 +++ b/soc/arm/microchip_mec/mec172x/power.c
 @@ -0,0 +1,189 @@
@@ -46515,7 +46236,7 @@ index 0000000000..7aaf3a8273
 +	}
 +}
 diff --git a/soc/arm/microchip_mec/mec172x/soc.c b/soc/arm/microchip_mec/mec172x/soc.c
-index dd1119a72f..9633a472c4 100644
+index dd1119a72..9633a472c 100644
 --- a/soc/arm/microchip_mec/mec172x/soc.c
 +++ b/soc/arm/microchip_mec/mec172x/soc.c
 @@ -16,6 +16,15 @@ static int soc_init(const struct device *dev)
@@ -46536,7 +46257,7 @@ index dd1119a72f..9633a472c4 100644
  
 diff --git a/soc/arm/microchip_mec/mec172x/soc_power_debug.h b/soc/arm/microchip_mec/mec172x/soc_power_debug.h
 new file mode 100644
-index 0000000000..e93114d13d
+index 000000000..e93114d13
 --- /dev/null
 +++ b/soc/arm/microchip_mec/mec172x/soc_power_debug.h
 @@ -0,0 +1,40 @@
@@ -46581,13 +46302,13 @@ index 0000000000..e93114d13d
 +
 +#endif /* __SOC_POWER_DEBUG_H__ */
 -- 
-2.17.1
+2.25.1
 
 
-From 29346dcaa66b8805d42a8eaf1c82384527dafe36 Mon Sep 17 00:00:00 2001
+From 6f7e9b91cfdaf20f6ed73590f36fdfde1ed0688c Mon Sep 17 00:00:00 2001
 From: Jose Alberto Meza <jose.a.meza.arellano@intel.com>
 Date: Fri, 20 May 2022 14:05:30 -0700
-Subject: [PATCH 103/112] soc: arm: microchip_mec: mec172x: Adjust SoC PM state
+Subject: [PATCH 102/111] soc: arm: microchip_mec: mec172x: Adjust SoC PM state
  function
 
 Zephyr PM subsystem SoC call change between on Zephyr 3.0.
@@ -46600,7 +46321,7 @@ Signed-off-by: Jose Alberto Meza <jose.a.meza.arellano@intel.com>
  1 file changed, 3 insertions(+), 4 deletions(-)
 
 diff --git a/soc/arm/microchip_mec/mec172x/power.c b/soc/arm/microchip_mec/mec172x/power.c
-index 7aaf3a8273..b702057dda 100644
+index 7aaf3a827..b702057dd 100644
 --- a/soc/arm/microchip_mec/mec172x/power.c
 +++ b/soc/arm/microchip_mec/mec172x/power.c
 @@ -12,6 +12,7 @@
@@ -46626,13 +46347,13 @@ index 7aaf3a8273..b702057dda 100644
  		z_power_soc_sleep();
  		break;
 -- 
-2.17.1
+2.25.1
 
 
-From daa5764946057f142422b995c64b480ecb10b2d5 Mon Sep 17 00:00:00 2001
+From 6ea78980c87cce000879b8ff92f30cf2103f14eb Mon Sep 17 00:00:00 2001
 From: Rajavardhan Gundi <rajavardhan.gundi@intel.com>
 Date: Mon, 18 Jul 2022 23:06:28 +0530
-Subject: [PATCH 104/112] boards: mec172xmodular_assy6930: Remove IO expander
+Subject: [PATCH 103/111] boards: mec172xmodular_assy6930: Remove IO expander
  configuration
 
 There is no IO Expander on the MECC. So, no point configuring it.
@@ -46643,7 +46364,7 @@ Signed-off-by: Rajavardhan Gundi <rajavardhan.gundi@intel.com>
  1 file changed, 17 deletions(-)
 
 diff --git a/boards/arm/mec172xmodular_assy6930/mec172xmodular_assy6930.dts b/boards/arm/mec172xmodular_assy6930/mec172xmodular_assy6930.dts
-index cd97eda88c..a3f8ae7476 100644
+index cd97eda88..a3f8ae747 100644
 --- a/boards/arm/mec172xmodular_assy6930/mec172xmodular_assy6930.dts
 +++ b/boards/arm/mec172xmodular_assy6930/mec172xmodular_assy6930.dts
 @@ -126,23 +126,6 @@
@@ -46671,13 +46392,13 @@ index cd97eda88c..a3f8ae7476 100644
  
  &i2c00_scl_gpio004 {
 -- 
-2.17.1
+2.25.1
 
 
-From ae03bca595d9a82e650186c36a08bb7d2deca4c3 Mon Sep 17 00:00:00 2001
+From 39918b0bc72ac2a6be53c2d02c53c8cf237dca39 Mon Sep 17 00:00:00 2001
 From: NagarajuGundimi <nagaraju.gundimi@intel.com>
 Date: Tue, 19 Jul 2022 11:35:38 +0530
-Subject: [PATCH 105/112] codeowners: Added backup owner for Alberto to unblock
+Subject: [PATCH 104/111] codeowners: Added backup owner for Alberto to unblock
  PR approval (#15)
 
 codeowners: Added backup owner for Alberto to unblock PR approval
@@ -46688,7 +46409,7 @@ Signed-off-by: NagarajuGundimi <nagaraju.gundimi@intel.com>
  1 file changed, 6 insertions(+), 6 deletions(-)
 
 diff --git a/CODEOWNERS b/CODEOWNERS
-index 756307b6f0..2a99f27d22 100644
+index 756307b6f..2a99f27d2 100644
 --- a/CODEOWNERS
 +++ b/CODEOWNERS
 @@ -222,7 +222,7 @@
@@ -46746,14 +46467,13 @@ index 756307b6f0..2a99f27d22 100644
  /include/drivers/pm_cpu_ops/              @carlocaione
  /include/app_memory/                      @dcpleung
 -- 
-2.17.1
+2.25.1
 
 
-From 428028b8a23683aa87bbe411cba54c90fbdd2a20 Mon Sep 17 00:00:00 2001
+From e2741ea7ed5fa79a9f936f04b39c16036fdfa03e Mon Sep 17 00:00:00 2001
 From: Aditya Bhutada <aditya.bhutada@intel.com>
 Date: Thu, 4 Aug 2022 16:53:03 -0700
-Subject: [PATCH 106/112] [BACKPORTED] eeprom: Add Microchip eeprom driver
- skeleton
+Subject: [PATCH 105/111] eeprom: Add Microchip eeprom driver skeleton
 
 Prepare for Microchip eeprom driver addition. Update
 dtsi, kconfig, cmake and relevant soc files for eeprom
@@ -46776,7 +46496,7 @@ Signed-off-by: Aditya Bhutada <aditya.bhutada@intel.com>
  create mode 100644 dts/bindings/mtd/microchip,xec-eeprom.yaml
 
 diff --git a/drivers/eeprom/CMakeLists.txt b/drivers/eeprom/CMakeLists.txt
-index eaac83a4f6..a5e5fce37e 100644
+index eaac83a4f..a5e5fce37 100644
 --- a/drivers/eeprom/CMakeLists.txt
 +++ b/drivers/eeprom/CMakeLists.txt
 @@ -10,3 +10,4 @@ zephyr_library_sources_ifdef(CONFIG_EEPROM_LPC11U6X eeprom_lpc11u6x.c)
@@ -46785,7 +46505,7 @@ index eaac83a4f6..a5e5fce37e 100644
  zephyr_library_sources_ifdef(CONFIG_EEPROM_EMULATOR eeprom_emulator.c)
 +zephyr_library_sources_ifdef(CONFIG_EEPROM_XEC eeprom_mchp_xec.c)
 diff --git a/drivers/eeprom/Kconfig b/drivers/eeprom/Kconfig
-index c6c40e5a4a..d64fc48ceb 100644
+index c6c40e5a4..d64fc48ce 100644
 --- a/drivers/eeprom/Kconfig
 +++ b/drivers/eeprom/Kconfig
 @@ -57,6 +57,7 @@ config EEPROM_AT2X_INIT_PRIORITY
@@ -46798,7 +46518,7 @@ index c6c40e5a4a..d64fc48ceb 100644
  	bool "Simulated EEPROM driver"
 diff --git a/drivers/eeprom/Kconfig.xec b/drivers/eeprom/Kconfig.xec
 new file mode 100644
-index 0000000000..953d87cdfd
+index 000000000..953d87cdf
 --- /dev/null
 +++ b/drivers/eeprom/Kconfig.xec
 @@ -0,0 +1,11 @@
@@ -46815,7 +46535,7 @@ index 0000000000..953d87cdfd
 +	  Enable support for Microchip XEC EEPROM driver.
 diff --git a/drivers/eeprom/eeprom_mchp_xec.c b/drivers/eeprom/eeprom_mchp_xec.c
 new file mode 100644
-index 0000000000..38e201fba0
+index 000000000..38e201fba
 --- /dev/null
 +++ b/drivers/eeprom/eeprom_mchp_xec.c
 @@ -0,0 +1,96 @@
@@ -46916,7 +46636,7 @@ index 0000000000..38e201fba0
 +		    &eeprom_config, POST_KERNEL,
 +		    CONFIG_EEPROM_INIT_PRIORITY, &eeprom_xec_api);
 diff --git a/dts/arm/microchip/mec172x/mec172xnsz-pinctrl.dtsi b/dts/arm/microchip/mec172x/mec172xnsz-pinctrl.dtsi
-index 36dabfc598..01ec0509a7 100644
+index 36dabfc59..01ec0509a 100644
 --- a/dts/arm/microchip/mec172x/mec172xnsz-pinctrl.dtsi
 +++ b/dts/arm/microchip/mec172x/mec172xnsz-pinctrl.dtsi
 @@ -641,6 +641,24 @@
@@ -46945,7 +46665,7 @@ index 36dabfc598..01ec0509a7 100644
  	peci_dat_gpio042: peci_dat_gpio042 {
  		pinmux = < MCHP_XEC_PINMUX(042, MCHP_AF1) >;
 diff --git a/dts/arm/microchip/mec172xnsz.dtsi b/dts/arm/microchip/mec172xnsz.dtsi
-index c934cb2060..b62b251312 100644
+index c934cb206..b62b25131 100644
 --- a/dts/arm/microchip/mec172xnsz.dtsi
 +++ b/dts/arm/microchip/mec172xnsz.dtsi
 @@ -515,6 +515,15 @@
@@ -46966,7 +46686,7 @@ index c934cb2060..b62b251312 100644
  			reg = <0x40004000 0x80>;
 diff --git a/dts/bindings/mtd/microchip,xec-eeprom.yaml b/dts/bindings/mtd/microchip,xec-eeprom.yaml
 new file mode 100644
-index 0000000000..08acb02f6d
+index 000000000..08acb02f6
 --- /dev/null
 +++ b/dts/bindings/mtd/microchip,xec-eeprom.yaml
 @@ -0,0 +1,32 @@
@@ -47003,7 +46723,7 @@ index 0000000000..08acb02f6d
 +    - regidx
 +    - bitpos
 diff --git a/soc/arm/microchip_mec/mec172x/Kconfig.defconfig.mec172xnsz b/soc/arm/microchip_mec/mec172x/Kconfig.defconfig.mec172xnsz
-index 5ca98bd3c1..4935c3c00b 100644
+index 5ca98bd3c..4935c3c00 100644
 --- a/soc/arm/microchip_mec/mec172x/Kconfig.defconfig.mec172xnsz
 +++ b/soc/arm/microchip_mec/mec172x/Kconfig.defconfig.mec172xnsz
 @@ -51,4 +51,8 @@ config PECI_XEC
@@ -47016,14 +46736,14 @@ index 5ca98bd3c1..4935c3c00b 100644
 +
  endif # SOC_MEC172X_NSZ
 -- 
-2.17.1
+2.25.1
 
 
-From 8be6d7ece6a28ed88a0b79e8c9f01254bff99435 Mon Sep 17 00:00:00 2001
+From c5f658a0bdce7fd17d677fa101b157aba376eaac Mon Sep 17 00:00:00 2001
 From: Aditya Bhutada <aditya.bhutada@intel.com>
 Date: Thu, 4 Aug 2022 16:56:38 -0700
-Subject: [PATCH 107/112] [BACKPORTED] drivers: eeprom: MEC172x - Add
- read/write APIs support
+Subject: [PATCH 106/111] drivers: eeprom: MEC172x - Add read/write APIs
+ support
 
 Add functions to support EEPROM read and EEPROM write.
 
@@ -47035,7 +46755,7 @@ Signed-off-by: Aditya Bhutada <aditya.bhutada@intel.com>
  2 files changed, 264 insertions(+), 15 deletions(-)
 
 diff --git a/drivers/eeprom/eeprom_mchp_xec.c b/drivers/eeprom/eeprom_mchp_xec.c
-index 38e201fba0..c89d6d1218 100644
+index 38e201fba..c89d6d121 100644
 --- a/drivers/eeprom/eeprom_mchp_xec.c
 +++ b/drivers/eeprom/eeprom_mchp_xec.c
 @@ -6,27 +6,232 @@
@@ -47385,7 +47105,7 @@ index 38e201fba0..c89d6d1218 100644
  		    &eeprom_config, POST_KERNEL,
  		    CONFIG_EEPROM_INIT_PRIORITY, &eeprom_xec_api);
 diff --git a/dts/bindings/mtd/microchip,xec-eeprom.yaml b/dts/bindings/mtd/microchip,xec-eeprom.yaml
-index 08acb02f6d..2b9a2237f2 100644
+index 08acb02f6..2b9a2237f 100644
 --- a/dts/bindings/mtd/microchip,xec-eeprom.yaml
 +++ b/dts/bindings/mtd/microchip,xec-eeprom.yaml
 @@ -5,7 +5,7 @@ description: Microchip on-chip EEPROM
@@ -47398,13 +47118,13 @@ index 08acb02f6d..2b9a2237f2 100644
  properties:
      reg:
 -- 
-2.17.1
+2.25.1
 
 
-From 845dbe60038141e28a4b7b8c8204092cca6e1881 Mon Sep 17 00:00:00 2001
+From ac59ec97264779ae3e049c14905597ab15be0c2b Mon Sep 17 00:00:00 2001
 From: Aditya Bhutada <aditya.bhutada@intel.com>
 Date: Thu, 4 Aug 2022 16:58:30 -0700
-Subject: [PATCH 108/112] [BACKPORTED] tests: eeprom: Add mec172x board overlay
+Subject: [PATCH 107/111] tests: eeprom: Add mec172x board overlay
 
 Add mec172xevb_assy6906 board overlay for eeprom test.
 
@@ -47417,7 +47137,7 @@ Signed-off-by: Aditya Bhutada <aditya.bhutada@intel.com>
 
 diff --git a/tests/drivers/eeprom/boards/mec172xevb_assy6906.overlay b/tests/drivers/eeprom/boards/mec172xevb_assy6906.overlay
 new file mode 100644
-index 0000000000..322a421bbe
+index 000000000..322a421bb
 --- /dev/null
 +++ b/tests/drivers/eeprom/boards/mec172xevb_assy6906.overlay
 @@ -0,0 +1,21 @@
@@ -47443,13 +47163,13 @@ index 0000000000..322a421bbe
 +	pinctrl-names = "default";
 +};
 -- 
-2.17.1
+2.25.1
 
 
-From 4b8582ff3b44f8e44b0d16376439b439e4a9593f Mon Sep 17 00:00:00 2001
+From 5b0e5fb30836f1d5e6c8ef501299a2761f88c592 Mon Sep 17 00:00:00 2001
 From: Aditya Bhutada <aditya.bhutada@intel.com>
 Date: Thu, 4 Aug 2022 17:10:58 -0700
-Subject: [PATCH 109/112] drivers: eeprom: eeprom_mchp_xec: Backward
+Subject: [PATCH 108/111] drivers: eeprom: eeprom_mchp_xec: Backward
  compatibility change
 
 Additional driver changes applied after backporting changes for EEPROM
@@ -47466,7 +47186,7 @@ Signed-off-by: Aditya Bhutada <aditya.bhutada@intel.com>
  2 files changed, 6 insertions(+), 5 deletions(-)
 
 diff --git a/drivers/eeprom/eeprom_mchp_xec.c b/drivers/eeprom/eeprom_mchp_xec.c
-index c89d6d1218..edc76ffb49 100644
+index c89d6d121..edc76ffb4 100644
 --- a/drivers/eeprom/eeprom_mchp_xec.c
 +++ b/drivers/eeprom/eeprom_mchp_xec.c
 @@ -6,15 +6,15 @@
@@ -47496,7 +47216,7 @@ index c89d6d1218..edc76ffb49 100644
 -		    CONFIG_EEPROM_INIT_PRIORITY, &eeprom_xec_api);
 +		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &eeprom_xec_api);
 diff --git a/dts/arm/microchip/mec172xnsz.dtsi b/dts/arm/microchip/mec172xnsz.dtsi
-index b62b251312..0bfca84844 100644
+index b62b25131..0bfca8484 100644
 --- a/dts/arm/microchip/mec172xnsz.dtsi
 +++ b/dts/arm/microchip/mec172xnsz.dtsi
 @@ -519,6 +519,7 @@
@@ -47508,14 +47228,14 @@ index b62b251312..0bfca84844 100644
  			girqs = <18 13>;
  			pcrs = <4 14>;
 -- 
-2.17.1
+2.25.1
 
 
-From 30f65a082d5c1e3922504deeac1a80fd96531f25 Mon Sep 17 00:00:00 2001
+From fade447ce64a4ba6eec7b477c1e0446c830e0638 Mon Sep 17 00:00:00 2001
 From: Jose Alberto Meza <jose.a.meza.arellano@intel.com>
 Date: Thu, 26 May 2022 18:43:46 -0700
-Subject: [PATCH 110/112] [BACKPORTED] boards: arm: mec172x: Configure KSI with
- internal pull-up
+Subject: [PATCH 109/111] boards: arm: mec172x: Configure KSI with internal
+ pull-up
 
 Even though possible to use external pull-up and open drain buffer,
 prefer internal pull-up to reduce power consumption.
@@ -47526,7 +47246,7 @@ Signed-off-by: Jose Alberto Meza <jose.a.meza.arellano@intel.com>
  1 file changed, 32 insertions(+)
 
 diff --git a/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts b/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts
-index f60aa683dc..443b075a24 100644
+index f60aa683d..443b075a2 100644
 --- a/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts
 +++ b/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts
 @@ -248,6 +248,38 @@
@@ -47569,14 +47289,14 @@ index f60aa683dc..443b075a24 100644
  	status = "okay";
  	pinctrl-0 = <&pwm0_gpio053>;
 -- 
-2.17.1
+2.25.1
 
 
-From 8a9b2fa7f92700dd8a83c3b36cfd9798b7a74ba5 Mon Sep 17 00:00:00 2001
+From 178d190cea31151047010986c2a075d484b007cf Mon Sep 17 00:00:00 2001
 From: Jay Vasanth <jay.vasanth@microchip.com>
 Date: Wed, 22 Jun 2022 15:48:32 -0400
-Subject: [PATCH 111/112] [BACKPORTED] soc: device_power: MEC172x: fix
- incorrect for loop check
+Subject: [PATCH 110/111] soc: device_power: MEC172x: fix incorrect for loop
+ check
 
 fix incorrect iteration condition in MEC172x device_power.c
 
@@ -47586,7 +47306,7 @@ Signed-off-by: Jay Vasanth <jay.vasanth@microchip.com>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/soc/arm/microchip_mec/mec172x/device_power.c b/soc/arm/microchip_mec/mec172x/device_power.c
-index e24b9cf184..ea42ad2b7b 100644
+index e24b9cf18..ea42ad2b7 100644
 --- a/soc/arm/microchip_mec/mec172x/device_power.c
 +++ b/soc/arm/microchip_mec/mec172x/device_power.c
 @@ -263,7 +263,7 @@ static void deep_sleep_save_blocks(void)
@@ -47608,13 +47328,13 @@ index e24b9cf184..ea42ad2b7b 100644
  				MCHP_I2C_SMB_CFG_OFS;
  
 -- 
-2.17.1
+2.25.1
 
 
-From ae03568ba99cbd1752ad9126841326129e3f69ec Mon Sep 17 00:00:00 2001
+From 3c81fcd4a0f4efcbd280b015186fc7280bcc4927 Mon Sep 17 00:00:00 2001
 From: "Chintha, Ramakrishna" <ramakrishna.chintha@intel.com>
 Date: Tue, 13 Sep 2022 12:19:49 +0530
-Subject: [PATCH 112/112] boards: mec172xmodular_assy6930: change drivestrength
+Subject: [PATCH 111/111] boards: mec172xmodular_assy6930: change drivestrength
  and mode
 
 Changing the mode to Quad from Dual and spi drivestrength to 8mA
@@ -47630,7 +47350,7 @@ Signed-off-by: Chintha, Ramakrishna <ramakrishna.chintha@intel.com>
 diff --git a/boards/arm/mec172xmodular_assy6930/support/spi_cfg_4MBit.txt b/boards/arm/mec172xmodular_assy6930/support/spi_cfg_4MBit.txt
 old mode 100644
 new mode 100755
-index 9b0d207282..e7afca5d2b
+index 9b0d20728..e7afca5d2
 --- a/boards/arm/mec172xmodular_assy6930/support/spi_cfg_4MBit.txt
 +++ b/boards/arm/mec172xmodular_assy6930/support/spi_cfg_4MBit.txt
 @@ -16,8 +16,8 @@ BoardID = 0
@@ -47645,5 +47365,5 @@ index 9b0d207282..e7afca5d2b
  SpiSignalControl = 0x00
  FwBinFile = zephyr.bin
 -- 
-2.17.1
+2.25.1
 


### PR DESCRIPTION
IRQn_Type had being define in soc/arm/microchip_mec/mec172x/soc.h after west manifest update

Currently patch will conflict with re-defined IRQn_Type in MEC172x soc.h and skip to apply conflict zephyr patches on to the kernel branch is necessary. Therefore remove applying IRQn_Type in MEC172x soc.h.

1. current commit of kernel branch 
   `1f3121b6b soc arm: MEC172x soc.h - Include custom IRQn_Type`

2. soc.h diff between patch and kernel branch
   [soc_arm_mec172x_soc_diff.txt](https://github.com/intel/ecfw-zephyr/files/9806041/soc_arm_mec172x_soc_diff.txt)

3. Remove part of patch with apply failed
  [zephyr_v2_7_oe_1_65_diff.txt](https://github.com/intel/ecfw-zephyr/files/9806101/zephyr_v2_7_oe_1_65_diff.txt)

Signed-off-by: JiaJun Yim <yimjiajun@icloud.com>