### PR TITLE
treewide: Include required header Zephyr mainline

### DIFF
--- a/app/smchost/smchost.c
+++ b/app/smchost/smchost.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include "board.h"
 #include "board_config.h"

--- a/app/smchost/smchost_pm.c
+++ b/app/smchost/smchost_pm.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/device.h>
 #include "port80display.h"

--- a/drivers/espi_hub.c
+++ b/drivers/espi_hub.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/drivers/espi.h>
 #include "espi_hub.h"


### PR DESCRIPTION
Including the headers to build on the latest Zephyr latest commit.