### PR TITLE
app: saf: removing spi_cfg.cs to NULL due to build failures

### DIFF
--- a/app/saf/saf_config.c
+++ b/app/saf/saf_config.c
@@ -259,7 +259,6 @@ int spi_flash_init(uint8_t slave_index)
 	spi_cfg.operation = SPI_OP_MODE_MASTER | SPI_TRANSFER_MSB
 			    | SPI_WORD_SET(8) | SPI_LINES_SINGLE;
 	spi_cfg.slave = 0;
-	spi_cfg.cs = NULL;
 
 	ret = qspi_read_status(slave_index);
 	if (ret) {


### PR DESCRIPTION
Build failures on latest zephyr commit due to cs is no longer a pointer.
    Here are the PR's which effects EC build:
    
    zephyrproject-rtos/zephyr#56576
    zephyrproject-rtos/zephyr#57264