### PR TITLE
boards: changing the property name and missed properties

### DIFF
--- a/app.overlay
+++ b/app.overlay
@@ -4,7 +4,5 @@
 
 &spi0 {
 	status = "okay";
-	port_sel = <0>;
-	chip_select = <0>;
 	lines = <4>;
 };

--- a/boards/mec172xmodular_assy6930.overlay
+++ b/boards/mec172xmodular_assy6930.overlay
@@ -35,8 +35,7 @@
 	status = "okay";
 	clock-frequency = <4000000>;
 	lines = <4>;
-	chip_select = <0>;
-	port_sel = <0>; /* Shared SPI */
+	chip-select = <0>;
 
 	pinctrl-0 = < &shd_cs0_n_gpio055
 		      &shd_clk_gpio056

--- a/out_of_tree_boards/boards/arm/mec1501_mtl_p/mec1501_mtl_p.dts
+++ b/out_of_tree_boards/boards/arm/mec1501_mtl_p/mec1501_mtl_p.dts
@@ -134,6 +134,10 @@
 };
 
 &spi0 {
+	status = "okay";
+	port-sel = <0>;
+	chip-select = <0>;
+	lines = <1>;
 	pinctrl-0 = < &shd_cs0_n_gpio055 &shd_clk_gpio056
 			&shd_io0_gpio223 &shd_io1_gpio224
 			&shd_io2_gpio227 &shd_io3_gpio016 >;

--- a/out_of_tree_boards/boards/arm/mec172x_mtl_s/mec172x_mtl_s.dts
+++ b/out_of_tree_boards/boards/arm/mec172x_mtl_s/mec172x_mtl_s.dts
@@ -188,10 +188,10 @@
 
 &spi0 {
 	status = "okay";
+	compatible = "microchip,xec-qmspi-ldma";
 	clock-frequency = <4000000>;
 	lines = <4>;
-	chip_select = <0>;
-	port_sel = <0>; /* Shared SPI */
+	chip-select = <0>;
 
 	pinctrl-0 = < &shd_cs0_n_gpio055
 		      &shd_clk_gpio056


### PR DESCRIPTION
Updated the dts and overlay files to reflect the changes in the property names and added the missing ones.