### PR TITLE
app: saf: Add support for SPI flash devices larger than 32MB 

### DIFF
--- a/app/saf/Kconfig
+++ b/app/saf/Kconfig
@@ -19,6 +19,9 @@ config SAF_SPI_CAPACITY
 	depends on ESPI_SAF
 	help
 	  Indicate SPI flash devices capacity in MB.
+	  This is used to configure SAF bridge size limit, if any attempt
+	  is done by the eSPI host to a flash address greater than this
+	  limit, it will cause an out-of-range error.
 
 config SAF_SPI_FREQ_MHZ
 	int "SAF SPI flash frequency"

--- a/app/saf/saf_spi_winbond.h
+++ b/app/saf/saf_spi_winbond.h
@@ -58,7 +58,7 @@
 #define SAF_RPMC_STATUS_DATA_OPCODE	0U
 
 /* Capacity adjustments */
-#if (CONFIG_SAF_SPI_CAPACITY == 32)
+#if (CONFIG_SAF_SPI_CAPACITY > 16)
 #define SAF_POLL_MASK		(MCHP_W25Q256_POLL2_MASK)
 
 #if DT_PROP(DT_SPI_INST, lines) == 4

--- a/boards/mec172xlj_mtl_template.conf
+++ b/boards/mec172xlj_mtl_template.conf
@@ -21,8 +21,8 @@ CONFIG_PECI_ACCESS_DISABLE_IN_CS=y
 # Support deprecated SMChost commands for backward compatibility
 CONFIG_DEPRECATED_SMCHOST_CMD=y
 
-# Enable gigadevice sequence
-CONFIG_SAF_ENABLE_XIP=y
+# Host needs to access 64MB SPI flash device
+CONFIG_SAF_SPI_CAPACITY=64
 
 # Zephyr kernel/driver configuration required by EC FW
 # ----------------------------------------------------

--- a/drivers/spi_winbond_opcodes.h
+++ b/drivers/spi_winbond_opcodes.h
@@ -30,22 +30,20 @@
 /* Map opcodes based on SPI flash capacity, since first require use 2-byte
  * addresses and later required 3-byte addresses.
  */
-#if (CONFIG_SAF_SPI_CAPACITY == 16)
+#if (CONFIG_SAF_SPI_CAPACITY < 32)
 #define PAGE_PROGRAM_OPCODE            0x02U
 #define SECTOR_ERASE_OPCODE            0x20U
 #define BLOCK_ERASE_64K_OPCODE         0xD8U
 #define FAST_READ_DUAL_IO_OPCODE       0xBBU
 #define FAST_READ_QUAD_IO_OPCODE       0xEBU
 #define QUAD_WRITE_DATA_OPCODE         0x32U
-#elif (CONFIG_SAF_SPI_CAPACITY == 32)
+#else
 #define PAGE_PROGRAM_OPCODE            0x12U
 #define SECTOR_ERASE_OPCODE            0x21U
 #define BLOCK_ERASE_64K_OPCODE         0xDCU
 #define FAST_READ_DUAL_IO_OPCODE       0xBCU
 #define FAST_READ_QUAD_IO_OPCODE       0xECU
 #define QUAD_WRITE_DATA_OPCODE         0x34U
-#else
-#pragma error "Unsupported SPI capacity"
 #endif
 
 #endif /* __SPI_WINBOND_OPCODES_H__ */


### PR DESCRIPTION
app: saf: spi_winbond: Add support for larger SPI flash devices

Even though same opcodes for 32MB can be used for larger devices, need to allow to set larger capacity to set correctly the SAF bridge flash size limit. 

Otherwise, any attempt done by the eSPI host to a flash address greater than this limit, it will result in an out-of-range error in eSPI.

