### PR TITLE
fix drivers/kbs_keymap.h: return invalid value when api no provided

### DIFF
--- a/drivers/kbs_keymap.h
+++ b/drivers/kbs_keymap.h
@@ -219,10 +219,14 @@ inline int keymap_get_keynum(struct km_api *api, uint8_t col, uint8_t row)
 	return api->get_keynum(col, row);
 }
 
-inline int keymap_get_fnkey(struct km_api *api, uint8_t key_num,
+static inline int keymap_get_fnkey(struct km_api *api, uint8_t key_num,
 			    struct fn_data *data,
 			    bool pressed)
 {
+	if (api == NULL) {
+		return -EINVAL;
+	}
+
 	if (api->get_fnkey == NULL) {
 		return -EINVAL;
 	}


### PR DESCRIPTION
To address issue #38 related to a usage fault occurring when pressing the left side <kbd>Shift</kbd> + <kbd>Ctrl</kbd> + <kbd>Alt</kbd> in combination with any keys, the problem arises from passing a NULL `struct km_api *api` parameter to a callback function without prior validation. This leads to the invocation of the callback function by offset from 0, triggering an exception handler.

To resolve this issue, it is essential to implement a check for the NULL condition of the `api` parameter before invoking the callback function. This precautionary measure ensures that the callback function is only called when a valid pointer is provided. The absence of this check currently results in a usage fault, particularly when the specified key combination is pressed on the left side.

The recommended fix involves incorporating a NULL check for the `api` parameter within the code. This validation step should precede the invocation of the callback function. By doing so, the code will handle the situation more gracefully, preventing the occurrence of unexpected exceptions or faults.

Please consider incorporating the provided guidance into the codebase to address and resolve issue #38 effectively.