### PR TITLE
oot: adlp: mtlp: Up/down and L/R shift not working in gtech keyboard

### DIFF
--- a/out_of_tree_boards/boards/arm/mec1501_adl_p/mec1501_adl_p.dts
+++ b/out_of_tree_boards/boards/arm/mec1501_adl_p/mec1501_adl_p.dts
@@ -203,7 +203,9 @@
 		      &kso10_gpio123
 		      &kso11_gpio124
 		      &kso12_gpio125
-		      &kso13_gpio126 >;
+		      &kso13_gpio126
+		      &kso14_gpio152
+		      &kso15_gpio151>;
 	pinctrl-names = "default";
 };
 

--- a/out_of_tree_boards/boards/arm/mec1501_mtl_p/mec1501_mtl_p.dts
+++ b/out_of_tree_boards/boards/arm/mec1501_mtl_p/mec1501_mtl_p.dts
@@ -203,7 +203,9 @@
 		      &kso10_gpio123
 		      &kso11_gpio124
 		      &kso12_gpio125
-		      &kso13_gpio126 >;
+		      &kso13_gpio126
+		      &kso14_gpio152
+		      &kso15_gpio151>;
 	pinctrl-names = "default";
 };
 


### PR DESCRIPTION
GPIO152 and GPIO51 are not configured as KSO pins. Missed device tree update when migrating from Zephyr 2.7 to 3.2

KSCAN pins | Register address | 1.71 | 2.01
-- | -- | -- | --
GPIO152/KSO14 | 400811A8 | 0x1041 | 0x448
GPIO151/KSO15 | 400811A4 | 0x2041 | 0x448
