### PR TITLE
fix espi_hub: remove repeated data send in peripheral callback

### DIFF
--- a/app/kbchost/kbchost.c
+++ b/app/kbchost/kbchost.c
@@ -742,22 +742,10 @@ int kbc_enable_interface(void)
 void kbc_handler(uint8_t data, uint8_t cmd_data)
 {
 	struct host_byte host_data;
-	static uint8_t repeated_data_hack;
 
 	host_data.data = data;
 	host_data.cmd = cmd_data;
 
-	/* Until we understand why the isrs are retriggered. This hack
-	 * is necessary in order to avoid returning FE due to  repeated
-	 * data which is processed in the DEFAULT_STATE. Therefore, fe
-	 * is returned and the host does not want to process further
-	 */
-
-	if (repeated_data_hack == data) {
-		return;
-	}
-
-	repeated_data_hack = data;
 	k_msgq_put(&from_host_queue, &host_data, K_NO_WAIT);
 }
 

--- a/drivers/espi_hub.c
+++ b/drivers/espi_hub.c
@@ -388,21 +388,13 @@ int espihub_init(void)
 			   ESPI_BUS_EVENT_CHANNEL_READY);
 	espi_init_callback(&hub.vw_cb, vwire_handler,
 			   ESPI_BUS_EVENT_VWIRE_RECEIVED);
-	espi_init_callback(&hub.p80_cb, periph_handler,
+	espi_init_callback(&hub.periph_cb, periph_handler,
 			   ESPI_BUS_PERIPHERAL_NOTIFICATION);
 
 	espi_add_callback(espi_dev, &hub.espi_bus_cb);
 	espi_add_callback(espi_dev, &hub.vw_rdy_cb);
 	espi_add_callback(espi_dev, &hub.vw_cb);
-	espi_add_callback(espi_dev, &hub.p80_cb);
-
-#ifdef CONFIG_ESPI_PERIPHERAL_8042_KBC
-
-	espi_init_callback(&hub.kbc_cb, periph_handler,
-				ESPI_BUS_PERIPHERAL_NOTIFICATION);
-	espi_add_callback(espi_dev, &hub.kbc_cb);
-
-#endif
+	espi_add_callback(espi_dev, &hub.periph_cb);
 
 #ifdef CONFIG_ESPI_OOB_CHANNEL_RX_ASYNC
 	espi_init_callback(&hub.oob_cb, espi_oob_rx_handler,

--- a/drivers/espi_hub.h
+++ b/drivers/espi_hub.h
@@ -73,10 +73,7 @@ struct espihub_context {
 	struct espi_callback espi_bus_cb;
 	struct espi_callback vw_rdy_cb;
 	struct espi_callback vw_cb;
-	struct espi_callback p80_cb;
-#ifdef CONFIG_ESPI_PERIPHERAL_8042_KBC
-	struct espi_callback kbc_cb;
-#endif
+	struct espi_callback periph_cb;
 #ifdef CONFIG_ESPI_OOB_CHANNEL_RX_ASYNC
 	struct espi_callback oob_cb;
 #endif


### PR DESCRIPTION
The fix ensures that the peripheral notification event is only triggered once in the callback function.

Previously, each call to espi_add_callback would insert the into a linked list.

This list would then be searched, and all matching ESPI_BUS_PERIPHERAL_NOTIFICATION events would be invoked when calling the callbacks.