### PR TITLE
treewide: Migrate open EC FW to Zephyr 3.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 set(BOARD_ROOT ${CMAKE_CURRENT_LIST_DIR}/out_of_tree_boards)
-include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(ecfw)
 
 include(${CMAKE_CURRENT_LIST_DIR}/app/CMakeLists.txt)

--- a/west.yml
+++ b/west.yml
@@ -24,19 +24,19 @@ manifest:
       repo-path: zephyr.git
       path: ecfwwork/zephyr_fork
       remote: zephyrproject
-      revision: v3.4.0
+      revision: v3.6.0
       clone-depth: 1
       west-commands: scripts/west-commands.yml
 
     - name: cmsis
+      revision: 4b96cbb174678dcd3ca86e11e1f24bc5f8726da0
       path: ecfwwork/modules/hal/cmsis
       remote: zephyrproject
-      revision: 74981bf893e8b10931464b9945e2143d99a3f0a3
 
     - name: hal_microchip
+      revision: 5d079f1683a00b801373bbbbf5d181d4e33b30d5
       path: ecfwwork/modules/hal/microchip
       remote: zephyrproject
-      revision: 5d079f1683a00b801373bbbbf5d181d4e33b30d5
 
   self:
     path: ecfwwork


### PR DESCRIPTION
Migrate EC FW to V3.6