### PR TITLE
app: saf: Decouple SAF from Zephyr SPI driver API

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -103,19 +103,7 @@ target_sources_ifdef(CONFIG_ESPI_PERIPHERAL_8042_KBC app
     ${CMAKE_CURRENT_LIST_DIR}/kbchost/keyboard_utility.h
     )
 
-target_sources_ifdef(CONFIG_ESPI_SAF app
-    PRIVATE
-    ${CMAKE_CURRENT_LIST_DIR}/saf/saf_config.c
-    PUBLIC
-    ${CMAKE_CURRENT_LIST_DIR}/saf/saf_config.h
-    )
-
-target_sources_ifdef(CONFIG_SAF_SPI_WINBOND app
-    PRIVATE
-    ${CMAKE_CURRENT_LIST_DIR}/saf/saf_spi_winbond.c
-    PUBLIC
-    ${CMAKE_CURRENT_LIST_DIR}/saf/saf_spi_winbond.h
-    )
+include(${CMAKE_CURRENT_LIST_DIR}/saf/CMakeLists.txt)
 
 target_include_directories(app
     PRIVATE

--- a/app/saf/CMakeLists.txt
+++ b/app/saf/CMakeLists.txt
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+
+
+target_sources_ifdef(CONFIG_ESPI_SAF app
+    PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/saf_config.c
+    PUBLIC
+    ${CMAKE_CURRENT_LIST_DIR}/saf_config.h
+    )
+
+target_sources_ifdef(CONFIG_SAF_SPI_WINBOND app
+    PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/saf_flash_config.c
+    ${CMAKE_CURRENT_LIST_DIR}/saf_spi_winbond.c
+    PUBLIC
+    ${CMAKE_CURRENT_LIST_DIR}/saf_spi_winbond.h
+    )

--- a/app/saf/Kconfig
+++ b/app/saf/Kconfig
@@ -32,6 +32,7 @@ config SAF_SPI_FREQ_MHZ
 
 config SAF_ENABLE_XIP
 	bool "Enable XIP when supported"
+	depends on SPI
 	depends on ESPI_SAF
 	help
 	  Indicate SPI flash has no continuous read enabled by default.
@@ -39,6 +40,7 @@ config SAF_ENABLE_XIP
 choice
 	prompt "Select your SAF SPI flash device"
 	default SAF_SPI_WINBOND
+	depends on SPI
 	depends on ESPI_SAF
 	help
 	 Select your SPI flash device vendor to allow to select correct

--- a/app/saf/saf_config.c
+++ b/app/saf/saf_config.c
@@ -7,47 +7,31 @@
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <soc.h>
-#include <zephyr/drivers/spi.h>
 #include <zephyr/drivers/espi.h>
 #include <zephyr/drivers/espi_saf.h>
 #include <zephyr/logging/log.h>
 #include "board_config.h"
 #include "saf_spi_transaction.h"
+#ifdef CONFIG_SAF_SPI_WINBOND
+#include "saf_spi_winbond.h"
+#endif
 #include "saf_config.h"
 
 LOG_MODULE_REGISTER(saf_config, CONFIG_ESPIHUB_LOG_LEVEL);
 
-#define SPI_RESET_DELAY_US             40U
-#define MHZ_TO_HZ(x)                   ((x) * 1000000U)
-#define MAX_SPI_RESPONSE               10U
+static const struct device *saf_dev = DEVICE_DT_GET(DT_ALIAS(espitaf));
 
-/* SPI opcodes are vendor-specific.
- * These are either used directly as commands sent via SPI driver
- * or used to initialize SAF HW registers.
- * SAF bridge then will translate the eSPI FLASH requests from host into
- * SPI transactions.
- */
-#ifdef CONFIG_SAF_SPI_WINBOND
-#include "saf_spi_winbond.h"
-#else
-#pragma error "Unsupported SAF SPI flash device"
-#endif
-
-#if DT_NODE_HAS_STATUS(DT_NODELABEL(spi0), disabled)
-#pragma error "spi hw block not enabled"
-#else
-#define DT_SPI_INST	DT_NODELABEL(spi0)
-#endif
-
-#if DT_PROP(DT_SPI_INST, lines) == 4
-#define SPI_IO_LINES	SPI_LINES_QUAD
-#else
-#define SPI_IO_LINES	SPI_LINES_DUAL
+#ifdef CONFIG_FLASH
+static struct espi_saf_cfg taf_cfg_flash = {
+	.nflash_devices = 1U,
+};
 #endif
 
 static const struct espi_saf_cfg *get_saf_cfg(void)
 {
-#ifdef CONFIG_SAF_SPI_WINBOND
+#ifdef CONFIG_FLASH
+	return &taf_cfg_flash;
+#elif CONFIG_SAF_SPI_WINBOND
 	return windbond_saf_cfg();
 #else
 #pragma error "Unsupported SAF SPI flash device"
@@ -55,295 +39,26 @@ static const struct espi_saf_cfg *get_saf_cfg(void)
 #endif
 }
 
-static struct saf_spi_transaction *spi_cmd(enum saf_command_index command)
-{
-#ifdef CONFIG_SAF_SPI_WINBOND
-	return windbond_qspi_cmd(command);
-#else
-#pragma error "Unsupported SAF SPI flash device"
-	return NULL;
-#endif
-}
-
-static const struct device *saf_dev;
-static const struct device *spi_dev;
-static struct spi_config spi_cfg;
-
-static int spi_send_cmd(uint8_t slave_index, struct saf_spi_transaction *cmd,
-			int mode)
-{
-	int ret;
-	uint8_t data[MAX_SPI_RESPONSE];
-#ifdef CONFIG_SPI_XEC_QMSPI_LDMA
-	struct spi_buf rx[2];
-	struct spi_buf tx[2];
-	struct spi_buf_set rx_bufs = {
-		.buffers = rx,
-		.count = 1,
-	};
-	struct spi_buf_set tx_bufs = {
-		.buffers = tx,
-		.count = 1,
-	};
-#else
-	struct spi_buf rx;
-	struct spi_buf tx;
-	struct spi_buf_set rx_bufs = {
-		.buffers = NULL,
-		.count = 0,
-	};
-	struct spi_buf_set tx_bufs = {
-		.buffers = &tx,
-		.count = 1,
-	};
-#endif
-
-#ifdef CONFIG_SPI_XEC_QMSPI_LDMA
-	tx[0].buf = cmd->buf;
-	tx[0].len = cmd->tx_len;
-	tx[1].buf = NULL;
-	tx[1].len = cmd->rx_len;
-
-	rx[0].buf = NULL;
-	rx[0].len = cmd->tx_len;
-	rx[1].buf = data;
-	rx[1].len = cmd->rx_len;
-#else
-	tx.buf = cmd->buf;
-	tx.len = cmd->tx_len;
-	rx.buf = data;
-	rx.len = cmd->rx_len;
-#endif
-	/* Increase SPI driver compatibility, do not indicate RX buffer despite
-	 * of the buffers been empty
-	 */
-	if (cmd->rx_len) {
-#ifdef CONFIG_SPI_XEC_QMSPI_LDMA
-		rx_bufs.count = 2;
-		tx_bufs.count = 2;
-#else
-		rx_bufs.buffers = &rx;
-		rx_bufs.count = 1;
-#endif
-	}
-
-	spi_cfg.operation = SPI_OP_MODE_MASTER | SPI_TRANSFER_MSB
-			    | SPI_WORD_SET(8) | mode;
-	spi_cfg.slave = slave_index;
-
-	/* Need to send empty rx buffer in dual/ quad mode for SPI LDMA driver */
-	if (IS_ENABLED(CONFIG_SPI_XEC_QMSPI_LDMA) && (mode != SPI_LINES_SINGLE)) {
-		ret = spi_transceive(spi_dev, &spi_cfg, &tx_bufs, NULL);
-	} else {
-		ret = spi_transceive(spi_dev, &spi_cfg, &tx_bufs, &rx_bufs);
-	}
-
-	if (ret < 0) {
-		LOG_ERR("SPI transceive error: %d", ret);
-		return ret;
-	}
-
-	return 0;
-}
-
-static int qspi_read_status(uint8_t slave_index)
-{
-	int ret;
-	struct saf_spi_transaction *spi_command;
-
-	LOG_DBG("%s ", __func__);
-
-	enum saf_command_index cmds[] = {
-		RD_STS1_CMD_INDEX, RD_STS2_CMD_INDEX, EN_RST_CMD_INDEX,
-		RD_STS1_CMD_INDEX, RD_STS1_CMD_INDEX
-	};
-
-
-	for (int i = 0; i < ARRAY_SIZE(cmds); i++) {
-		spi_command = spi_cmd(cmds[i]);
-		if (spi_command != NULL) {
-			ret = spi_send_cmd(slave_index, spi_command,
-					 SPI_LINES_SINGLE);
-			if (ret) {
-				return ret;
-			}
-		} else {
-			return -EINVAL;
-		}
-
-	}
-
-	return 0;
-}
-
-#ifdef CONFIG_SAF_ENABLE_XIP
-int qspi_enable_xip(uint8_t slave_index)
-{
-	int ret = 0;
-	struct saf_spi_transaction *spi_command;
-
-	LOG_INF("%s", __func__);
-	enum saf_command_index cmds[] = { WRITE_ENABLE_INDEX,
-		WRITE_NV_REGISTER_INDEX,
-		READ_NV_REGISTER_INDEX };
-
-	for (int i = 0; i < ARRAY_SIZE(cmds); i++) {
-		spi_command = spi_cmd(cmds[i]);
-		if (spi_command != NULL) {
-			ret = spi_send_cmd(slave_index, spi_command,
-				 SPI_LINES_SINGLE);
-			if (ret) {
-				LOG_ERR("SPI command failed %d", ret);
-				return ret;
-			}
-		} else {
-			LOG_ERR("Invalid command");
-			return -EINVAL;
-		}
-	}
-
-	return 0;
-}
-#endif
-
-static int qspi_reset_spi_flash_device(uint8_t slave_index)
-{
-	int ret;
-	struct saf_spi_transaction *spi_command;
-
-	LOG_DBG("%s", __func__);
-
-	enum saf_command_index cmds[] = { EN_RST_CMD_INDEX, RST_CMD_INDEX };
-
-	for (int i = 0; i < ARRAY_SIZE(cmds); i++) {
-		spi_command = spi_cmd(cmds[i]);
-		if (spi_command != NULL) {
-			ret = spi_send_cmd(slave_index, spi_command,
-					SPI_IO_LINES);
-			if (ret) {
-				return ret;
-			}
-		} else {
-			return -EINVAL;
-		}
-	}
-
-	k_busy_wait(SPI_RESET_DELAY_US);
-
-#ifdef CONFIG_SAF_ENABLE_XIP
-	qspi_enable_xip(slave_index);
-#endif
-
-	/* For SPI flash devices with capacity over 16MB, need to enable
-	 * 4-byte address mode
-	 */
-#if (CONFIG_SAF_SPI_CAPACITY == 32)
-	ret = spi_send_cmd(slave_index, spi_cmd(FOUR_BYTE_CMD_INDEX),
-	     SPI_LINES_SINGLE);
-#endif
-
-	return ret;
-}
-
-static int qspi_exit_continuous_mode(uint8_t slave_index)
-{
-	int ret;
-	struct spi_buf tx;
-
-	struct spi_buf_set rx_bufs = {
-		.buffers = NULL,
-		.count = 0,
-	};
-
-	struct spi_buf_set tx_bufs = {
-		.buffers = &tx,
-		.count = 1,
-	};
-
-	LOG_DBG("%s", __func__);
-	tx.buf = NULL;
-	tx.len = 9;
-
-	spi_cfg.operation = SPI_OP_MODE_MASTER | SPI_TRANSFER_MSB
-			    | SPI_WORD_SET(8) | SPI_IO_LINES;
-	spi_cfg.slave = slave_index;
-
-	/* Need to send empty rx buffer in dual/ quad mode for SPI LDMA driver */
-	if (IS_ENABLED(CONFIG_SPI_XEC_QMSPI_LDMA)) {
-		ret = spi_transceive(spi_dev, &spi_cfg, &tx_bufs, NULL);
-	} else {
-		ret = spi_transceive(spi_dev, &spi_cfg, &tx_bufs, &rx_bufs);
-	}
-
-	if (ret < 0) {
-		LOG_ERR("SPI transceive error: %d", ret);
-		return ret;
-	}
-
-	return 0;
-}
-
-int spi_flash_init(uint8_t slave_index)
-{
-	int ret;
-
-	LOG_DBG("%s", __func__);
-
-	spi_dev = DEVICE_DT_GET(SPI_0);
-	if (!device_is_ready(spi_dev)) {
-		LOG_ERR("SPI device not ready");
-		return -ENODEV;
-	};
-
-	spi_cfg.frequency = MHZ_TO_HZ(CONFIG_SAF_SPI_FREQ_MHZ);
-	spi_cfg.operation = SPI_OP_MODE_MASTER | SPI_TRANSFER_MSB
-			    | SPI_WORD_SET(8) | SPI_LINES_SINGLE;
-	spi_cfg.slave = 0;
-
-	ret = qspi_read_status(slave_index);
-	if (ret) {
-		LOG_ERR("Fail to read SPI flash device sts: %d", ret);
-		return ret;
-	}
-
-	ret = qspi_exit_continuous_mode(slave_index);
-	if (ret) {
-		LOG_ERR("Fail to exit continuous mode: %d", ret);
-		return ret;
-	}
-
-	ret = qspi_reset_spi_flash_device(slave_index);
-	if (ret) {
-		LOG_ERR("Fail to reset SPI flash device: %d", ret);
-		return ret;
-	}
-
-	return 0;
-}
-
 int initialize_saf_bridge(void)
 {
 	int ret;
 	bool saf_ready;
 
-	saf_dev = DEVICE_DT_GET(ESPI_SAF_0);
 	if (!device_is_ready(saf_dev)) {
 		LOG_ERR("ESPI SAF device not ready");
 		return -ENODEV;
 	}
 
-	LOG_DBG("%d SPI flash devices", CONFIG_SAF_SPI_DEVICES_COUNT);
-	LOG_DBG("Capacity %d  MB", CONFIG_SAF_SPI_CAPACITY);
-	LOG_DBG("Frequency %d", CONFIG_SAF_SPI_FREQ_MHZ);
-
+#ifdef CONFIG_SPI
 	/* SAF requires that SPI flash device is reset and in Quad mode */
 	for (int i = 0; i < CONFIG_SAF_SPI_DEVICES_COUNT; i++) {
-		ret = spi_flash_init(i);
+		ret = saf_spi_init(i);
 		if (ret) {
 			LOG_ERR("Fail to init SPI device %d: %d", i, ret);
 			return ret;
 		}
 	}
+#endif
 
 	ret = espi_saf_config(saf_dev, get_saf_cfg());
 	if (ret) {

--- a/app/saf/saf_flash_config.c
+++ b/app/saf/saf_flash_config.c
@@ -1,0 +1,310 @@
+/*
+ * Copyright (c) 2021 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <soc.h>
+#include <zephyr/drivers/spi.h>
+#include <zephyr/logging/log.h>
+#include "board_config.h"
+#include "saf_spi_transaction.h"
+LOG_MODULE_DECLARE(saf_config, CONFIG_ESPIHUB_LOG_LEVEL);
+
+#define SPI_RESET_DELAY_US             40U
+#define MHZ_TO_HZ(x)                   ((x) * 1000000U)
+#define MAX_SPI_RESPONSE               10U
+#define QSPI_EXIT_CONTINUOUS_TRANS_LEN 9U
+
+/* SPI opcodes are vendor-specific.
+ * These are either used directly as commands sent via SPI driver
+ * or used to initialize SAF HW registers.
+ * SAF bridge then will translate the eSPI FLASH requests from host into
+ * SPI transactions.
+ */
+#ifdef CONFIG_FLASH
+#elif CONFIG_SAF_SPI_WINBOND
+#include "saf_spi_winbond.h"
+#else
+#pragma error "Unsupported SAF SPI flash device"
+#endif
+
+#if DT_NODE_HAS_STATUS(DT_ALIAS(spi0), disabled)
+#pragma error "spi hw block not enabled"
+#else
+#define DT_SPI_INST	DT_ALIAS(spi0)
+#endif
+
+#if DT_PROP(DT_SPI_INST, lines) == 4
+#define SPI_IO_LINES	SPI_LINES_QUAD
+#else
+#define SPI_IO_LINES	SPI_LINES_DUAL
+#endif
+
+static const struct device *spi_dev;
+static struct spi_config spi_cfg;
+
+static struct saf_spi_transaction *spi_cmd(enum saf_command_index command)
+{
+#ifdef CONFIG_SAF_SPI_WINBOND
+	return windbond_qspi_cmd(command);
+#else
+#pragma error "Unsupported SAF SPI flash device"
+	return NULL;
+#endif
+}
+
+static int spi_send_cmd(uint8_t slave_index, struct saf_spi_transaction *cmd,
+			int mode)
+{
+	int ret;
+	uint8_t data[MAX_SPI_RESPONSE];
+#ifdef CONFIG_SPI_XEC_QMSPI_LDMA
+	struct spi_buf rx[2];
+	struct spi_buf tx[2];
+	struct spi_buf_set rx_bufs = {
+		.buffers = rx,
+		.count = 1,
+	};
+	struct spi_buf_set tx_bufs = {
+		.buffers = tx,
+		.count = 1,
+	};
+#else
+	struct spi_buf rx;
+	struct spi_buf tx;
+	struct spi_buf_set rx_bufs = {
+		.buffers = NULL,
+		.count = 0,
+	};
+
+	struct spi_buf_set tx_bufs = {
+		.buffers = &tx,
+		.count = 1,
+	};
+#endif
+
+#ifdef CONFIG_SPI_XEC_QMSPI_LDMA
+	tx[0].buf = cmd->buf;
+	tx[0].len = cmd->tx_len;
+	tx[1].buf = NULL;
+	tx[1].len = cmd->rx_len;
+
+	rx[0].buf = NULL;
+	rx[0].len = cmd->tx_len;
+	rx[1].buf = data;
+	rx[1].len = cmd->rx_len;
+#else
+	tx.buf = cmd->buf;
+	tx.len = cmd->tx_len;
+	rx.buf = data;
+	rx.len = cmd->rx_len;
+#endif
+	/* Increase SPI driver compatibility, do not indicate RX buffer despite
+	 * of the buffers been empty
+	 */
+	if (cmd->rx_len) {
+#ifdef CONFIG_SPI_XEC_QMSPI_LDMA
+		rx_bufs.count = 2;
+		tx_bufs.count = 2;
+#else
+		rx_bufs.buffers = &rx;
+		rx_bufs.count = 1;
+#endif
+	}
+
+	spi_cfg.operation = SPI_OP_MODE_MASTER | SPI_TRANSFER_MSB
+			    | SPI_WORD_SET(8) | mode;
+	spi_cfg.slave = slave_index;
+
+	/* Need to send empty rx buffer in dual/ quad mode for SPI LDMA driver */
+	if (IS_ENABLED(CONFIG_SPI_XEC_QMSPI_LDMA) && (mode != SPI_LINES_SINGLE)) {
+		ret = spi_transceive(spi_dev, &spi_cfg, &tx_bufs, NULL);
+	} else {
+		ret = spi_transceive(spi_dev, &spi_cfg, &tx_bufs, &rx_bufs);
+	}
+
+	if (ret < 0) {
+		LOG_ERR("SPI transceive error: %d", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+static int qspi_read_status(uint8_t slave_index)
+{
+	int ret;
+	struct saf_spi_transaction *spi_command;
+
+	LOG_DBG("%d", slave_index);
+	enum saf_command_index cmds[] = {
+		RD_STS1_CMD_INDEX, RD_STS2_CMD_INDEX, EN_RST_CMD_INDEX,
+		RD_STS1_CMD_INDEX, RD_STS1_CMD_INDEX
+	};
+
+
+	for (int i = 0; i < ARRAY_SIZE(cmds); i++) {
+		spi_command = spi_cmd(cmds[i]);
+		if (spi_command != NULL) {
+			ret = spi_send_cmd(slave_index, spi_command,
+					 SPI_LINES_SINGLE);
+			if (ret) {
+				return ret;
+			}
+		} else {
+			return -EINVAL;
+		}
+
+	}
+
+	return 0;
+}
+
+#ifdef CONFIG_SAF_ENABLE_XIP
+int qspi_enable_xip(uint8_t slave_index)
+{
+	int ret = 0;
+	struct saf_spi_transaction *spi_command;
+
+	LOG_INF("%s", __func__);
+	enum saf_command_index cmds[] = { WRITE_ENABLE_INDEX,
+		WRITE_NV_REGISTER_INDEX,
+		READ_NV_REGISTER_INDEX };
+
+	for (int i = 0; i < ARRAY_SIZE(cmds); i++) {
+		spi_command = spi_cmd(cmds[i]);
+		if (spi_command != NULL) {
+			ret = spi_send_cmd(slave_index, spi_command,
+				 SPI_LINES_SINGLE);
+			if (ret) {
+				LOG_ERR("SPI command failed %d", ret);
+				return ret;
+			}
+		} else {
+			LOG_ERR("Invalid command");
+			return -EINVAL;
+		}
+	}
+
+	return 0;
+}
+#endif
+
+static int qspi_reset_spi_flash_device(uint8_t slave_index)
+{
+	int ret;
+	struct saf_spi_transaction *spi_command;
+
+	LOG_DBG("%d", slave_index);
+	enum saf_command_index cmds[] = { EN_RST_CMD_INDEX, RST_CMD_INDEX };
+
+	for (int i = 0; i < ARRAY_SIZE(cmds); i++) {
+		spi_command = spi_cmd(cmds[i]);
+		if (spi_command != NULL) {
+			ret = spi_send_cmd(slave_index, spi_command,
+					SPI_IO_LINES);
+			if (ret) {
+				return ret;
+			}
+		} else {
+			return -EINVAL;
+		}
+	}
+
+	k_busy_wait(SPI_RESET_DELAY_US);
+
+#ifdef CONFIG_SAF_ENABLE_XIP
+	qspi_enable_xip(slave_index);
+#endif
+
+	/* For SPI flash devices with capacity over 16MB, need to enable
+	 * 4-byte address mode
+	 */
+#if (CONFIG_SAF_SPI_CAPACITY == 32)
+	ret = spi_send_cmd(slave_index, spi_cmd(FOUR_BYTE_CMD_INDEX),
+	     SPI_LINES_SINGLE);
+#endif
+
+	return ret;
+}
+
+static int qspi_exit_continuous_mode(uint8_t slave_index)
+{
+	int ret;
+	struct spi_buf tx;
+
+	struct spi_buf_set rx_bufs = {
+		.buffers = NULL,
+		.count = 0,
+	};
+
+	struct spi_buf_set tx_bufs = {
+		.buffers = &tx,
+		.count = 1,
+	};
+
+	LOG_DBG("%d", slave_index);
+	tx.buf = NULL;
+	tx.len = QSPI_EXIT_CONTINUOUS_TRANS_LEN;
+
+	spi_cfg.operation = SPI_OP_MODE_MASTER | SPI_TRANSFER_MSB
+			    | SPI_WORD_SET(8) | SPI_IO_LINES;
+	spi_cfg.slave = slave_index;
+
+	/* Need to send empty rx buffer in dual/ quad mode for SPI LDMA driver */
+	if (IS_ENABLED(CONFIG_SPI_XEC_QMSPI_LDMA)) {
+		ret = spi_transceive(spi_dev, &spi_cfg, &tx_bufs, NULL);
+	} else {
+		ret = spi_transceive(spi_dev, &spi_cfg, &tx_bufs, &rx_bufs);
+	}
+
+	if (ret < 0) {
+		LOG_ERR("SPI transceive error: %d", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+int saf_spi_init(uint8_t slave_index)
+{
+	int ret;
+
+	LOG_DBG("%d SPI flash devices", CONFIG_SAF_SPI_DEVICES_COUNT);
+	LOG_DBG("Capacity %d  MB", CONFIG_SAF_SPI_CAPACITY);
+	LOG_DBG("Frequency %d", CONFIG_SAF_SPI_FREQ_MHZ);
+
+	spi_dev = DEVICE_DT_GET(DT_ALIAS(spi0));
+	if (!device_is_ready(spi_dev)) {
+		LOG_ERR("SPI device not ready");
+		return -ENODEV;
+	};
+
+	spi_cfg.frequency = MHZ_TO_HZ(CONFIG_SAF_SPI_FREQ_MHZ);
+	spi_cfg.operation = SPI_OP_MODE_MASTER | SPI_TRANSFER_MSB
+			    | SPI_WORD_SET(8) | SPI_LINES_SINGLE;
+	spi_cfg.slave = 0;
+
+	ret = qspi_read_status(slave_index);
+	if (ret) {
+		LOG_ERR("Fail to read SPI flash device sts: %d", ret);
+		return ret;
+	}
+
+	ret = qspi_exit_continuous_mode(slave_index);
+	if (ret) {
+		LOG_ERR("Fail to exit continuous mode: %d", ret);
+		return ret;
+	}
+
+	ret = qspi_reset_spi_flash_device(slave_index);
+	if (ret) {
+		LOG_ERR("Fail to reset SPI flash device: %d", ret);
+		return ret;
+	}
+
+	return 0;
+}

--- a/app/saf/saf_spi_transaction.h
+++ b/app/saf/saf_spi_transaction.h
@@ -41,4 +41,6 @@ struct saf_spi_transaction {
 	uint8_t mode;
 };
 
+int saf_spi_init(uint8_t slave_index);
+
 #endif /* __SAF_SPI_TRANSACTION_H__ */

--- a/app/saf/saf_spi_winbond.h
+++ b/app/saf/saf_spi_winbond.h
@@ -10,10 +10,10 @@
 #include "spi_winbond_opcodes.h"
 
 /* Adjust descriptors based on SPI capacity to simplify SAF structure */
-#if DT_NODE_HAS_STATUS(DT_NODELABEL(spi0), disabled)
+#if DT_NODE_HAS_STATUS(DT_ALIAS(spi0), disabled)
 #pragma error "spi hw block not enabled"
 #else
-#define DT_SPI_INST	DT_NODELABEL(spi0)
+#define DT_SPI_INST	DT_ALIAS(spi0)
 #if DT_PROP(DT_SPI_INST, lines) == 4
 #define FAST_READ_IO_OPCODE            FAST_READ_QUAD_IO_OPCODE
 #else

--- a/drivers/spi_winbond_opcodes.h
+++ b/drivers/spi_winbond_opcodes.h
@@ -37,6 +37,8 @@
 #define WRITE_VOLATILE_CFG_OPCODE      0x81U
 
 /* Macronix SPI commands */
+#define MXIC_SECTOR_ERASE_OPCODE       0x21U
+#define MXIC_QUAD_WRITE_DATA_OPCODE    0x02U
 #define MXIC_SAF_POLL_MASK             0xfff3U
 
 /* Map opcodes based on SPI flash capacity, since first require use 2-byte

--- a/out_of_tree_boards/boards/arm/mec172x_mtl_s/mec172x_mtl_s.dts
+++ b/out_of_tree_boards/boards/arm/mec172x_mtl_s/mec172x_mtl_s.dts
@@ -27,7 +27,8 @@
 		i2c-0 = &i2c_smb_0;
 		i2c1 = &i2c_smb_1;
 		i2c7 = &i2c_smb_2;
-
+		espitaf = &espi_saf0;
+		spi0 = &spi0;
 	};
 
 	zephyr,user {


### PR DESCRIPTION
Allow no SPI initialization via SPI driver sequences 
Move SPI flash initialization in separate file
Add app saf module CMakelist to allow library in the future