### PR TITLE
app: treewide: Add individual CMakelist for each ECFW module

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -16,92 +16,18 @@ include_directories(app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/app/kbchost)
 include_directories(app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/app/saf)
 include_directories(app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/app/soc_debug_awareness)
 
-#
+include(${CMAKE_CURRENT_LIST_DIR}/peripheral_management/CMakeLists.txt)
+include(${CMAKE_CURRENT_LIST_DIR}/power_sequencing/CMakeLists.txt)
+include(${CMAKE_CURRENT_LIST_DIR}/dnx/CMakeLists.txt)
+include(${CMAKE_CURRENT_LIST_DIR}/soc_debug_awareness/CMakeLists.txt)
 
-target_sources_ifdef(CONFIG_PERIPHERAL_MANAGEMENT app
-    PRIVATE
-    ${CMAKE_CURRENT_LIST_DIR}/peripheral_management/periphmgmt.c
-    ${CMAKE_CURRENT_LIST_DIR}/peripheral_management/pwrbtnmgmt.c
-    PUBLIC
-    ${CMAKE_CURRENT_LIST_DIR}/peripheral_management/periphmgmt.h
-    ${CMAKE_CURRENT_LIST_DIR}/peripheral_management/pwrbtnmgmt.h
-    )
+include(${CMAKE_CURRENT_LIST_DIR}/smchost/CMakeLists.txt)
 
-target_sources_ifdef(CONFIG_PWRMGMT app
-    PRIVATE
-    ${CMAKE_CURRENT_LIST_DIR}/power_sequencing/pwrplane.c
-    ${CMAKE_CURRENT_LIST_DIR}/power_sequencing/dswmode.c
-    ${CMAKE_CURRENT_LIST_DIR}/power_sequencing/deepsx.c
-    ${CMAKE_CURRENT_LIST_DIR}/power_sequencing/pseudog3.c
-    ${CMAKE_CURRENT_LIST_DIR}/power_sequencing/pmc.c
-    ${CMAKE_CURRENT_LIST_DIR}/power_sequencing/pwrseq_utils.c
-    PUBLIC
-    ${CMAKE_CURRENT_LIST_DIR}/power_sequencing/pwrplane.h
-    ${CMAKE_CURRENT_LIST_DIR}/power_sequencing/dswmode.h
-    ${CMAKE_CURRENT_LIST_DIR}/power_sequencing/deepsx.h
-    ${CMAKE_CURRENT_LIST_DIR}/power_sequencing/pseudog3.h
-    ${CMAKE_CURRENT_LIST_DIR}/power_sequencing/pmc.h
-    ${CMAKE_CURRENT_LIST_DIR}/power_sequencing/pwrseq_utils.h
-    )
+include(${CMAKE_CURRENT_LIST_DIR}/thermal_management/CMakeLists.txt)
 
-target_sources_ifdef(CONFIG_DNX_SUPPORT app
-    PRIVATE
-    ${CMAKE_CURRENT_LIST_DIR}/dnx/dnx.c
-    PUBLIC
-    ${CMAKE_CURRENT_LIST_DIR}/dnx/dnx.h
-    )
+include(${CMAKE_CURRENT_LIST_DIR}/debug/CMakeLists.txt)
+include(${CMAKE_CURRENT_LIST_DIR}/kbchost/CMakeLists.txt)
 
-target_sources_ifdef(CONFIG_DNX_EC_ASSISTED_TRIGGER app
-    PRIVATE
-    ${CMAKE_CURRENT_LIST_DIR}/dnx/dnx_ec_assisted_trigger.c
-    PUBLIC
-    ${CMAKE_CURRENT_LIST_DIR}/dnx/dnx_ec_assisted_trigger.h
-    )
-
-target_sources_ifdef(CONFIG_SOC_DEBUG_AWARENESS app
-    PRIVATE
-    ${CMAKE_CURRENT_LIST_DIR}/soc_debug_awareness/soc_debug.c
-    PUBLIC
-    ${CMAKE_CURRENT_LIST_DIR}/soc_debug_awareness/soc_debug.h
-    )
-
-target_sources_ifdef(CONFIG_SMCHOST app
-    PRIVATE
-    ${CMAKE_CURRENT_LIST_DIR}/smchost/smchost.c
-    ${CMAKE_CURRENT_LIST_DIR}/smchost/smchost_info.c
-    ${CMAKE_CURRENT_LIST_DIR}/smchost/smchost_pm.c
-    ${CMAKE_CURRENT_LIST_DIR}/smchost/smc.c
-    ${CMAKE_CURRENT_LIST_DIR}/smchost/sci.c
-    PUBLIC
-    ${CMAKE_CURRENT_LIST_DIR}/smchost/smchost.h
-    ${CMAKE_CURRENT_LIST_DIR}/smchost/smc.h
-    ${CMAKE_CURRENT_LIST_DIR}/smchost/sci.h
-    ${CMAKE_CURRENT_LIST_DIR}/smchost/scicodes.h
-    )
-
-target_sources_ifdef(CONFIG_THERMAL_MANAGEMENT app
-    PRIVATE
-    ${CMAKE_CURRENT_LIST_DIR}/thermal_management/thermalmgmt.c
-    ${CMAKE_CURRENT_LIST_DIR}/smchost/smchost_thermal.c
-    PUBLIC
-    ${CMAKE_CURRENT_LIST_DIR}/thermal_management/thermalmgmt.h
-    )
-
-target_sources_ifdef(CONFIG_POSTCODE_MANAGEMENT app
-    PRIVATE
-    ${CMAKE_CURRENT_LIST_DIR}/debug/postcodemgmt.c
-    PUBLIC
-    ${CMAKE_CURRENT_LIST_DIR}/debug/postcodemgmt.h
-    )
-
-target_sources_ifdef(CONFIG_ESPI_PERIPHERAL_8042_KBC app
-    PRIVATE
-    ${CMAKE_CURRENT_LIST_DIR}/kbchost/kbchost.c
-    ${CMAKE_CURRENT_LIST_DIR}/kbchost/keyboard_utility.c
-    PUBLIC
-    ${CMAKE_CURRENT_LIST_DIR}/kbchost/kbchost.h
-    ${CMAKE_CURRENT_LIST_DIR}/kbchost/keyboard_utility.h
-    )
 
 target_sources_ifdef(CONFIG_ESPI_SAF app
     PRIVATE

--- a/app/debug/CMakeLists.txt
+++ b/app/debug/CMakeLists.txt
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+
+target_sources_ifdef(CONFIG_POSTCODE_MANAGEMENT app
+    PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/postcodemgmt.c
+    PUBLIC
+    ${CMAKE_CURRENT_LIST_DIR}/postcodemgmt.h
+    )
+

--- a/app/dnx/CMakeLists.txt
+++ b/app/dnx/CMakeLists.txt
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+
+target_sources_ifdef(CONFIG_DNX_SUPPORT app
+    PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/dnx.c
+    PUBLIC
+    ${CMAKE_CURRENT_LIST_DIR}/dnx.h
+    )
+
+target_sources_ifdef(CONFIG_DNX_EC_ASSISTED_TRIGGER app
+    PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/dnx_ec_assisted_trigger.c
+    PUBLIC
+    ${CMAKE_CURRENT_LIST_DIR}/dnx_ec_assisted_trigger.h
+    )

--- a/app/kbchost/CMakeLists.txt
+++ b/app/kbchost/CMakeLists.txt
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+
+target_sources_ifdef(CONFIG_ESPI_PERIPHERAL_8042_KBC app
+    PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/kbchost.c
+    ${CMAKE_CURRENT_LIST_DIR}/keyboard_utility.c
+    PUBLIC
+    ${CMAKE_CURRENT_LIST_DIR}/kbchost.h
+    ${CMAKE_CURRENT_LIST_DIR}/keyboard_utility.h
+    )

--- a/app/peripheral_management/CMakeLists.txt
+++ b/app/peripheral_management/CMakeLists.txt
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+
+target_sources_ifdef(CONFIG_PERIPHERAL_MANAGEMENT app
+    PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/periphmgmt.c
+    ${CMAKE_CURRENT_LIST_DIR}/pwrbtnmgmt.c
+    PUBLIC
+    ${CMAKE_CURRENT_LIST_DIR}/periphmgmt.h
+    ${CMAKE_CURRENT_LIST_DIR}/pwrbtnmgmt.h
+    )

--- a/app/power_sequencing/CMakeLists.txt
+++ b/app/power_sequencing/CMakeLists.txt
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+
+target_sources_ifdef(CONFIG_PWRMGMT app
+    PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/pwrplane.c
+    ${CMAKE_CURRENT_LIST_DIR}/dswmode.c
+    ${CMAKE_CURRENT_LIST_DIR}/deepsx.c
+    ${CMAKE_CURRENT_LIST_DIR}/pseudog3.c
+    ${CMAKE_CURRENT_LIST_DIR}/pmc.c
+    ${CMAKE_CURRENT_LIST_DIR}/pwrseq_utils.c
+    PUBLIC
+    ${CMAKE_CURRENT_LIST_DIR}/pwrplane.h
+    ${CMAKE_CURRENT_LIST_DIR}/dswmode.h
+    ${CMAKE_CURRENT_LIST_DIR}/deepsx.h
+    ${CMAKE_CURRENT_LIST_DIR}/pseudog3.h
+    ${CMAKE_CURRENT_LIST_DIR}/pmc.h
+    ${CMAKE_CURRENT_LIST_DIR}/pwrseq_utils.h
+    )

--- a/app/smchost/CMakeLists.txt
+++ b/app/smchost/CMakeLists.txt
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+
+target_sources_ifdef(CONFIG_SMCHOST app
+    PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/smchost.c
+    ${CMAKE_CURRENT_LIST_DIR}/smchost_info.c
+    ${CMAKE_CURRENT_LIST_DIR}/smchost_pm.c
+    ${CMAKE_CURRENT_LIST_DIR}/smc.c
+    ${CMAKE_CURRENT_LIST_DIR}/sci.c
+    PUBLIC
+    ${CMAKE_CURRENT_LIST_DIR}/acpi_region.h
+    ${CMAKE_CURRENT_LIST_DIR}/smchost.h
+    ${CMAKE_CURRENT_LIST_DIR}/smc.h
+    ${CMAKE_CURRENT_LIST_DIR}/sci.h
+    ${CMAKE_CURRENT_LIST_DIR}/scicodes.h
+    )
+
+target_sources_ifdef(CONFIG_PFAT_SUPPORT app
+    PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/smchost_pfat.c
+    )
+
+target_sources_ifdef(CONFIG_THERMAL_MANAGEMENT app
+    PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/smchost_thermal.c
+    )

--- a/app/soc_debug_awareness/CMakeLists.txt
+++ b/app/soc_debug_awareness/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+
+target_sources_ifdef(CONFIG_SOC_DEBUG_AWARENESS app
+    PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/soc_debug.c
+    PUBLIC
+    ${CMAKE_CURRENT_LIST_DIR}/soc_debug.h
+    )

--- a/app/thermal_management/CMakeLists.txt
+++ b/app/thermal_management/CMakeLists.txt
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+
+if (CONFIG_THERMAL_MANAGEMENT)
+    target_sources(app
+        PRIVATE
+        ${CMAKE_CURRENT_LIST_DIR}/thermalmgmt.c
+        PUBLIC
+        ${CMAKE_CURRENT_LIST_DIR}/thermalmgmt.h
+        )
+endif()


### PR DESCRIPTION
Create independent CMakelist so app modules are self-contained