### PR TITLE
misc: Re-distribute stack based on puncover analysis

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -22,6 +22,7 @@ rsource "app/power_management/Kconfig"
 rsource "app/dnx/Kconfig"
 rsource "app/soc_debug_awareness/Kconfig"
 rsource "boards/Kconfig"
+rsource "misc/Kconfig"
 
 endmenu
 

--- a/app/debug/Kconfig
+++ b/app/debug/Kconfig
@@ -12,6 +12,13 @@ config POSTCODE_MANAGEMENT
 	  Indicate if BIOS debug port 80 block is enabled and the values
 	  are intercepted and display in 7-segment display array.
 
+config POST_TASK_STACK_SIZE
+	int "Adjust post management thread stack size"
+	depends on POSTCODE_MANAGEMENT
+	default 1024
+	help
+	 EC FW postcode management thread task stack size.
+
 config POSTCODE_LOG_LEVEL
 	int "Debug Port80 log level"
 	depends on POSTCODE_MANAGEMENT

--- a/app/debug/Kconfig
+++ b/app/debug/Kconfig
@@ -15,7 +15,9 @@ config POSTCODE_MANAGEMENT
 config POST_TASK_STACK_SIZE
 	int "Adjust post management thread stack size"
 	depends on POSTCODE_MANAGEMENT
-	default 1024
+	default 372 if ECFW_STACK_OPTIMIZATION
+	default 588 if POSTCODE_LOG_LEVEL > 2
+	default 496
 	help
 	 EC FW postcode management thread task stack size.
 

--- a/app/kbchost/Kconfig
+++ b/app/kbchost/Kconfig
@@ -32,6 +32,20 @@ config KSCAN_EC
 	  PS/2 and keyboard scan matrix use the same application interfaces
 	  to communicate information from/to the host.
 
+config KBC_TASK_STACK_SIZE
+	int "Adjust host keyboard management thread stack size"
+	default 500 if SOC_IT8XXX2
+	default 500 if SOC_FAMILY_MEC
+	help
+	 EC FW keyboard management thread task stack size.
+
+config KB_TASK_STACK_SIZE
+	int "Adjust keyboard matrix/PS2 devices management thread stack size"
+	default 452 if SOC_IT8XXX2
+	default 384 if SOC_FAMILY_MEC
+	help
+	 EC FW keyboard matrix/PS2 device management thread task stack size.
+
 config KBCHOST_LOG_LEVEL
 	int "kbchost log level"
 	depends on LOG

--- a/app/kbchost/Kconfig
+++ b/app/kbchost/Kconfig
@@ -34,15 +34,21 @@ config KSCAN_EC
 
 config KBC_TASK_STACK_SIZE
 	int "Adjust host keyboard management thread stack size"
+	default 402 if ECFW_STACK_OPTIMIZATION
+	default 684 if KBCHOST_LOG_LEVEL > 2
 	default 500 if SOC_IT8XXX2
-	default 500 if SOC_FAMILY_MEC
+	default 572 if SOC_FAMILY_MEC
+	default 500
 	help
 	 EC FW keyboard management thread task stack size.
 
 config KB_TASK_STACK_SIZE
 	int "Adjust keyboard matrix/PS2 devices management thread stack size"
+	default 276 if ECFW_STACK_OPTIMIZATION
+	default 508 if KBCHOST_LOG_LEVEL > 2
 	default 452 if SOC_IT8XXX2
-	default 384 if SOC_FAMILY_MEC
+	default 468 if SOC_FAMILY_MEC
+	default 468
 	help
 	 EC FW keyboard matrix/PS2 device management thread task stack size.
 

--- a/app/peripheral_management/Kconfig
+++ b/app/peripheral_management/Kconfig
@@ -23,7 +23,9 @@ config PERIPHERAL_DEBOUNCE_TIME
 
 config PERIPH_TASK_STACK_SIZE
 	int "Adjust peripheral management thread stack size"
-	default 1024
+	default 252 if ECFW_STACK_OPTIMIZATION
+	default 876 if PERIPHERAL_LOG_LEVEL > 2
+	default 716
 	help
 	 EC FW peripheral management thread task stack size.
 

--- a/app/peripheral_management/Kconfig
+++ b/app/peripheral_management/Kconfig
@@ -21,6 +21,12 @@ config PERIPHERAL_DEBOUNCE_TIME
 	  Indicate time in milliseconds used to debounce buttons
 	  and switches for user interaction.
 
+config PERIPH_TASK_STACK_SIZE
+	int "Adjust peripheral management thread stack size"
+	default 1024
+	help
+	 EC FW peripheral management thread task stack size.
+
 config PERIPHERAL_LOG_LEVEL
 	int "Peripheral log level"
 	depends on PERIPHERAL_MANAGEMENT

--- a/app/power_sequencing/Kconfig
+++ b/app/power_sequencing/Kconfig
@@ -12,6 +12,12 @@ config POWER_SEQUENCE_DISABLE_TIMEOUTS
 	help
 	  Indicate if EC will enforce timeouts during power sequencing or not.
 
+config PWR_TASK_STACK_SIZE
+	int "Adjust power plane thread stack size"
+	default 1024
+	help
+	 EC FW power plane management thread task stack size.
+
 config POWER_SEQUENCE_MINIMUM_ESPI_CAPS
 	bool "eSPI handshake with minimum capabilities"
 	help

--- a/app/power_sequencing/Kconfig
+++ b/app/power_sequencing/Kconfig
@@ -14,7 +14,9 @@ config POWER_SEQUENCE_DISABLE_TIMEOUTS
 
 config PWR_TASK_STACK_SIZE
 	int "Adjust power plane thread stack size"
-	default 1024
+	default 432 if ECFW_STACK_OPTIMIZATION
+	default 1820 if PWRMGT_LOG_LEVEL > 2
+	default 1004
 	help
 	 EC FW power plane management thread task stack size.
 

--- a/app/smchost/Kconfig
+++ b/app/smchost/Kconfig
@@ -14,7 +14,9 @@ config SMCHOST
 
 config SMC_TASK_STACK_SIZE
 	int "Adjust System management controller thread stack size"
-	default 1024
+	default 444 if ECFW_STACK_OPTIMIZATION
+	default 1372 if SMCHOST_LOG_LEVEL > 2
+	default 804
 	help
 	 EC FW System management controller thread task stack size.
 

--- a/app/smchost/Kconfig
+++ b/app/smchost/Kconfig
@@ -12,6 +12,12 @@ config SMCHOST
 	help
 	  Enables EC communication to BIOS.
 
+config SMC_TASK_STACK_SIZE
+	int "Adjust System management controller thread stack size"
+	default 1024
+	help
+	 EC FW System management controller thread task stack size.
+
 config SMCHOST_SCI_OVER_ESPI
 	bool "Enable SCI support over eSPI"
 	default y

--- a/app/thermal_management/Kconfig
+++ b/app/thermal_management/Kconfig
@@ -16,7 +16,9 @@ config THERMAL_MANAGEMENT
 config THERMAL_TASK_STACK_SIZE
 	int "Adjust thermal management thread stack size"
 	depends on THERMAL_MANAGEMENT
-	default 1024
+	default 762 if ECFW_STACK_OPTIMIZATION
+	default 1892 if THERMAL_MGMT_LOG_LEVEL > 2
+	default 1164
 	help
 	 EC FW thermal management thread task stack size.
 

--- a/app/thermal_management/Kconfig
+++ b/app/thermal_management/Kconfig
@@ -13,6 +13,13 @@ config THERMAL_MANAGEMENT
 	  Indicate if EC supports management of fan, reading thermal
 	  sensors and cpu temperature.
 
+config THERMAL_TASK_STACK_SIZE
+	int "Adjust thermal management thread stack size"
+	depends on THERMAL_MANAGEMENT
+	default 1024
+	help
+	 EC FW thermal management thread task stack size.
+
 config THERMAL_FAN_OVERRIDE
 	bool "Enable fan override"
 	help

--- a/drivers/Kconfig
+++ b/drivers/Kconfig
@@ -63,7 +63,9 @@ config OOBMNGR_SUPPORT
 
 config OOBMNGR_TASK_STACK_SIZE
 	int "Adjust eSPI OOB manager thread stack size"
-	default 512
+	default 498 if ECFW_STACK_OPTIMIZATION
+	default 892 if ESPIOOB_MNGR_LOG_LEVEL > 2
+	default 748
 	help
 	 EC FW eSPI Out-of-band channel manager thread task stack size.
 

--- a/drivers/Kconfig
+++ b/drivers/Kconfig
@@ -61,6 +61,12 @@ config OOBMNGR_SUPPORT
 	  Enable EC support for OOB manager eSPI hub extension to tunnel all
 	  the OOB traffic through OOB manager APIs.
 
+config OOBMNGR_TASK_STACK_SIZE
+	int "Adjust eSPI OOB manager thread stack size"
+	default 512
+	help
+	 EC FW eSPI Out-of-band channel manager thread task stack size.
+
 config ENABLE_ESPI_LTR
 	bool "Enable Latency Tolerance Reporting"
 	help

--- a/misc/Kconfig
+++ b/misc/Kconfig
@@ -1,0 +1,20 @@
+# Kconfig - Config options for EC FW app
+#
+# Copyright (c) 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+menu "EC FW modules stack configuration"
+
+config ECFW_STACK_OPTIMIZATION
+	bool "Enable EC FW stack optimizations"
+	help
+	 Use minimum thread stack for each EC FW module.
+	 Depending on the work that some task must some tasks may require more
+	 or less stack space than the default value.
+
+config MAIN_STACK_SIZE
+	default 512 if ECFW_STACK_OPTIMIZATION
+
+endmenu

--- a/misc/task_handler.c
+++ b/misc/task_handler.c
@@ -20,8 +20,9 @@
 #include "thermalmgmt.h"
 #endif
 
-LOG_MODULE_DECLARE(pwrmgmt, CONFIG_PWRMGT_LOG_LEVEL);
+LOG_MODULE_DECLARE(ecfw, CONFIG_EC_LOG_LEVEL);
 
+#define THREAD_STATE_MAX_SIZE	12U
 #define EC_TASK_STACK_SIZE	1024
 
 /* K_FOREVER can no longer be used with K_THREAD_DEFINE
@@ -39,41 +40,40 @@ const uint32_t smchost_thrd_period = 10;
 	(defined(CONFIG_PS2_KEYBOARD) || defined(CONFIG_PS2_MOUSE) || \
 	defined(CONFIG_KSCAN_EC))
 
-#define KBC_TASK_STACK_SIZE	500
-#define KB_TASK_STACK_SIZE	384
-K_THREAD_DEFINE(kbc_thrd_id, KBC_TASK_STACK_SIZE, to_from_host_thread,
+K_THREAD_DEFINE(kbc_thrd_id, CONFIG_KBC_TASK_STACK_SIZE, to_from_host_thread,
 		NULL, NULL, NULL, EC_TASK_PRIORITY, 0, EC_WAIT_FOREVER);
-K_THREAD_DEFINE(kb_thrd_id, KB_TASK_STACK_SIZE, to_host_kb_thread,
+K_THREAD_DEFINE(kb_thrd_id, CONFIG_KB_TASK_STACK_SIZE, to_host_kb_thread,
 		NULL, NULL, NULL, EC_TASK_PRIORITY, 0, EC_WAIT_FOREVER);
 #endif
 
 #ifdef CONFIG_POSTCODE_MANAGEMENT
 const uint32_t postcode_thrd_period = 125;
-K_THREAD_DEFINE(postcode_thrd_id, EC_TASK_STACK_SIZE, postcode_thread,
+K_THREAD_DEFINE(postcode_thrd_id, CONFIG_POST_TASK_STACK_SIZE, postcode_thread,
 		&postcode_thrd_period, NULL, NULL, EC_TASK_PRIORITY,
 		K_INHERIT_PERMS, EC_WAIT_FOREVER);
 #endif
 
-K_THREAD_DEFINE(periph_thrd_id, EC_TASK_STACK_SIZE, periph_thread,
+K_THREAD_DEFINE(periph_thrd_id, CONFIG_PERIPH_TASK_STACK_SIZE, periph_thread,
 		&periph_thrd_period, NULL, NULL, EC_TASK_PRIORITY,
 		K_INHERIT_PERMS, EC_WAIT_FOREVER);
 
-K_THREAD_DEFINE(pwrseq_thrd_id, EC_TASK_STACK_SIZE, pwrseq_thread,
+K_THREAD_DEFINE(pwrseq_thrd_id, CONFIG_PWR_TASK_STACK_SIZE, pwrseq_thread,
 		&pwrseq_thrd_period, NULL, NULL, EC_TASK_PRIORITY,
 		K_INHERIT_PERMS, EC_WAIT_FOREVER);
 
-#define OOBMNGR_TASK_STACK_SIZE		512U
-K_THREAD_DEFINE(oobmngr_thrd_id, OOBMNGR_TASK_STACK_SIZE, oobmngr_thread,
-		NULL, NULL, NULL, EC_TASK_PRIORITY,
+#define OOBMNGR_TASK_PRIORITY	K_PRIO_COOP(3)
+K_THREAD_DEFINE(oobmngr_thrd_id, CONFIG_OOBMNGR_TASK_STACK_SIZE, oobmngr_thread,
+		NULL, NULL, NULL, OOBMNGR_TASK_PRIORITY,
 		K_INHERIT_PERMS, EC_WAIT_FOREVER);
 
-K_THREAD_DEFINE(smchost_thrd_id, EC_TASK_STACK_SIZE, smchost_thread,
+K_THREAD_DEFINE(smchost_thrd_id, CONFIG_SMC_TASK_STACK_SIZE, smchost_thread,
 		&smchost_thrd_period, NULL, NULL, EC_TASK_PRIORITY,
 		K_INHERIT_PERMS, EC_WAIT_FOREVER);
 
 #ifdef CONFIG_THERMAL_MANAGEMENT
 const uint32_t thermal_thrd_period = 250;
-K_THREAD_DEFINE(thermal_thrd_id, EC_TASK_STACK_SIZE, thermalmgmt_thread,
+K_THREAD_DEFINE(thermal_thrd_id, CONFIG_THERMAL_TASK_STACK_SIZE,
+		thermalmgmt_thread,
 		&thermal_thrd_period, NULL, NULL, EC_TASK_PRIORITY,
 		K_INHERIT_PERMS, EC_WAIT_FOREVER);
 #endif


### PR DESCRIPTION
Re-distribute stack based on puncover analysis, instead of
having 1Kb for each thread.
There are thread that are assigned less than required.

Add 3 stack values for each thread:

1) Default. Thread stack is set to maximum between 2 times
worst-case stack release and worst-case debug.
MAX(2X WC release, 1X WC debug log level=2).
Note: Intended for official release/debug binaries.

2) Debug. Thread stack is set to 1 time worst case stack
when debug log level for the respective  module is set to verbose.
Note: Intended for engineering debug binaries with custom logging

3) Optimized. Thread stack is set 1.5 times worst-case stack
whenever the KConfig switch is enabled.
This is intended for research only.
