### PR TITLE
drivers: gpio: Constify gpio configuration arrays

### DIFF
--- a/boards/microchip/mtl_s_mec172x.c
+++ b/boards/microchip/mtl_s_mec172x.c
@@ -18,6 +18,7 @@
 uint8_t platformskutype;
 
 LOG_MODULE_DECLARE(board, CONFIG_BOARD_LOG_LEVEL);
+
 /** @brief EC FW app owned gpios list.
  *
  * This list is not exhaustive, it do not include driver-owned pins,
@@ -31,7 +32,7 @@ LOG_MODULE_DECLARE(board, CONFIG_BOARD_LOG_LEVEL);
  */
 
 /* APP-owned gpios */
-struct gpio_ec_config mecc172x_cfg[] = {
+static const struct gpio_ec_config mecc172x_cfg[] = {
 	{ PM_SLP_SUS,		GPIO_INPUT },
 	{ EC_SPI_CS1_N,		GPIO_OUTPUT_HIGH},
 	{ EC_GPIO_011,		GPIO_INPUT },
@@ -83,20 +84,20 @@ struct gpio_ec_config mecc172x_cfg[] = {
 };
 
 /* APP-owned GPIOs for MTL-S CRB */
-struct gpio_ec_config mecc172x_cfg_mtl_s_crb_divergence[] = {
+static const struct gpio_ec_config mecc172x_cfg_mtl_s_crb_divergence[] = {
 	{ PM_PWRBTN_CRB,		GPIO_OUTPUT_HIGH | GPIO_OPEN_DRAIN },
 	{ KBC_NUM_LOCK_CRB,		GPIO_OUTPUT_LOW },
 };
 
 /* APP-owned GPIOs for MTL-P DDR5 SBS*/
-struct gpio_ec_config mecc172x_cfg_mtl_s_erb_divergence[] = {
+static const struct gpio_ec_config mecc172x_cfg_mtl_s_erb_divergence[] = {
 	{ PM_PWRBTN_ERB,		GPIO_OUTPUT_HIGH | GPIO_OPEN_DRAIN },
 	{ KBC_NUM_LOCK_ERB,		GPIO_OUTPUT_LOW },
 };
 
 
 /* Any IO expanders pins should be defined here */
-struct gpio_ec_config expander_cfg[] = {
+static const struct gpio_ec_config expander_cfg[] = {
 #ifdef CONFIG_GPIO_PCA95XX
 	{ SPD_PRSNT,		GPIO_INPUT },
 	{ DISPLAY_ID_0,		GPIO_INPUT },
@@ -113,10 +114,10 @@ struct gpio_ec_config expander_cfg[] = {
 #endif
 };
 
-struct gpio_ec_config mecc172x_cfg_sus[] =  {
+static const struct gpio_ec_config mecc172x_cfg_sus[] =  {
 };
 
-struct gpio_ec_config mecc172x_cfg_res[] =  {
+static const struct gpio_ec_config mecc172x_cfg_res[] =  {
 };
 
 #ifdef CONFIG_THERMAL_MANAGEMENT

--- a/boards/microchip/ptl_uh_mec172x.c
+++ b/boards/microchip/ptl_uh_mec172x.c
@@ -33,7 +33,7 @@ uint8_t pd_i2c_addr_set;
  */
 
 /* APP-owned gpios */
-struct gpio_ec_config mecc172x_cfg[] = {
+static const struct gpio_ec_config mecc172x_cfg[] = {
 	{ HOME_BUTTON,		GPIO_INPUT },
 	{ EC_GPIO_002,		GPIO_DISCONNECTED },
 	{ PM_SLP_SUS,		GPIO_DISCONNECTED },
@@ -78,14 +78,10 @@ struct gpio_ec_config mecc172x_cfg[] = {
 	{ VOL_DOWN,		GPIO_INPUT | GPIO_INT_EDGE_BOTH },
 	{ STD_ADPT_CNTRL_GPIO,	GPIO_OUTPUT_LOW },
 	{ CATERR_LED_DRV,		GPIO_DISCONNECTED},
-
-	/* Not used */
-	{ SLP_S0_PLT_EC_N,		GPIO_DISCONNECTED },
-
 };
 
 /* Any IO expanders pins should be defined here */
-struct gpio_ec_config expander_cfg[] = {
+static const struct gpio_ec_config expander_cfg[] = {
 #ifdef CONFIG_GPIO_PCA95XX
 	{ SPD_PRSNT,		GPIO_INPUT },
 	{ VIRTUAL_BAT,		GPIO_INPUT },
@@ -100,10 +96,10 @@ struct gpio_ec_config expander_cfg[] = {
 #endif
 };
 
-struct gpio_ec_config mecc172x_cfg_sus[] =  {
+static const struct gpio_ec_config mecc172x_cfg_sus[] =  {
 };
 
-struct gpio_ec_config mecc172x_cfg_res[] =  {
+static const struct gpio_ec_config mecc172x_cfg_res[] =  {
 };
 
 #ifdef CONFIG_THERMAL_MANAGEMENT

--- a/boards/nuvoton/npcx4m8f_mecc/npcx4m8f_aic_on_ptl.c
+++ b/boards/nuvoton/npcx4m8f_mecc/npcx4m8f_aic_on_ptl.c
@@ -34,7 +34,7 @@ uint8_t pd_i2c_addr_set;
  *
  */
 
-static struct gpio_ec_config mecc_npcx9_cfg[] =  {
+static const struct gpio_ec_config mecc_npcx9_cfg[] =  {
 /*      Port Signal			Config       */
 	{ PWRBTN_EC_IN_N,		GPIO_INPUT | GPIO_INT_EDGE_BOTH },
 	{ SMC_LID,			GPIO_INPUT  | GPIO_INT_EDGE_BOTH },
@@ -73,7 +73,7 @@ static struct gpio_ec_config mecc_npcx9_cfg[] =  {
 };
 
 /* Any IO expanders pins should be defined here */
-static struct gpio_ec_config expander_cfg[] = {
+static const struct gpio_ec_config expander_cfg[] = {
 #ifdef CONFIG_GPIO_PCA95XX
 	{ SPD_PRSNT,		GPIO_INPUT },
 	{ MOD_TCSS1_DETECT,	GPIO_INPUT },
@@ -92,11 +92,11 @@ static struct gpio_ec_config expander_cfg[] = {
 };
 
 /* This action is performed explicitly, just adding here as reference */
-static struct gpio_ec_config mecc_npcx9_cfg_sus[] =  {
+static const struct gpio_ec_config mecc_npcx9_cfg_sus[] =  {
 	{ PCH_PWROK,			GPIO_OUTPUT_LOW },
 };
 
-static struct gpio_ec_config mecc_npcx9_cfg_res[] =  {
+static const struct gpio_ec_config mecc_npcx9_cfg_res[] =  {
 	{ PCH_PWROK,			GPIO_OUTPUT_HIGH },
 };
 

--- a/drivers/gpio_ec.h
+++ b/drivers/gpio_ec.h
@@ -87,7 +87,7 @@ int gpio_configure_pin(uint32_t port_pin, gpio_flags_t flags);
  *
  * @retval 0 if successful, negative errno code on failure.
  */
-int gpio_configure_array(struct gpio_ec_config *gpios, uint32_t len);
+int gpio_configure_array(const struct gpio_ec_config *gpios, uint32_t len);
 
 /**
  * @brief Set the level for a pin.

--- a/drivers/gpio_ec.h
+++ b/drivers/gpio_ec.h
@@ -13,7 +13,7 @@
  * @brief GPIO driver wrapper APIS.
  */
 #define EC_GPIO_PORT_POS	8U
-#define EC_GPIO_PORT_MASK	((uint32_t) 0xfU << EC_GPIO_PORT_POS)
+#define EC_GPIO_PORT_MASK	((uint32_t)0x1fU << EC_GPIO_PORT_POS)
 #define EC_GPIO_PIN_POS		0U
 #define EC_GPIO_PIN_MASK	((uint32_t)0x1fU << EC_GPIO_PIN_POS)
 

--- a/drivers/gpio_mec.c
+++ b/drivers/gpio_mec.c
@@ -122,7 +122,7 @@ int gpio_configure_pin(uint32_t port_pin, gpio_flags_t flags)
 	return 0;
 }
 
-int gpio_configure_array(struct gpio_ec_config *gpios, uint32_t len)
+int gpio_configure_array(const struct gpio_ec_config *gpios, uint32_t len)
 {
 	int ret;
 	struct gpio_port_pin pp;

--- a/drivers/gpio_mec.c
+++ b/drivers/gpio_mec.c
@@ -50,15 +50,18 @@ uint32_t get_absolute_gpio_num(uint32_t port_pin)
 static int validate_device(uint32_t port_pin, struct gpio_port_pin *pp)
 {
 	uint32_t port_idx;
-	gpio_pin_t pin;
 
 	port_idx = gpio_get_port(port_pin);
-	pin = gpio_get_pin(port_pin);
+	pp->pin = gpio_get_pin(port_pin);
 
 	/* Fail gracefully when GPIO table is misconfigured which easily
 	 * results in a CPU fault
 	 */
 	if (port_idx >= ARRAY_SIZE(ports)) {
+		if (gpio_get_port(port_pin) == EC_DUMMY_GPIO_PORT) {
+			LOG_DBG("dummy port");
+		}
+
 		return -EINVAL;
 	}
 
@@ -68,10 +71,9 @@ static int validate_device(uint32_t port_pin, struct gpio_port_pin *pp)
 	}
 
 	LOG_DBG("%s: port idx: %d port ptr: %p pin: %d",
-		__func__, port_idx, ports[port_idx], pin);
+		__func__, port_idx, ports[port_idx], pp->pin);
 
 	pp->gpio_dev = ports[port_idx];
-	pp->pin = pin;
 
 	return 0;
 }

--- a/drivers/gpio_npcx.c
+++ b/drivers/gpio_npcx.c
@@ -134,7 +134,7 @@ int gpio_configure_pin(uint32_t port_pin, gpio_flags_t flags)
 	return 0;
 }
 
-int gpio_configure_array(struct gpio_ec_config *gpios, uint32_t len)
+int gpio_configure_array(const struct gpio_ec_config *gpios, uint32_t len)
 {
 	int ret;
 	struct gpio_port_pin pp;


### PR DESCRIPTION
Constify parameter to allow use of constant data.
Save data RAM by moving gpio configuration tables into code space.