### PR TITLE
Fix miscellaneous adaptation layer Coverity issues

### DIFF
--- a/drivers/adc_sensors.c
+++ b/drivers/adc_sensors.c
@@ -11,6 +11,7 @@
 #include <zephyr/drivers/adc.h>
 #include "adc_sensors.h"
 #include "board_config.h"
+#include "memops.h"
 LOG_MODULE_REGISTER(adcsens, CONFIG_ADC_SENSORS_LOG_LEVEL);
 
 /* For cases where ADC failure occurs during LPM exit, PLL takes 3ms to lock */
@@ -283,6 +284,7 @@ void adc_sensors_read_all(void)
 	int ret;
 	int16_t adc_raw_val[num_of_adc_ch];
 	uint8_t ch, ch_cnt = 0;
+	memsets(adc_raw_val, 0, sizeof(adc_raw_val));
 
 	const struct adc_sequence sequence = {
 		.channels	= adc_ch_bits,

--- a/drivers/eeprom.c
+++ b/drivers/eeprom.c
@@ -35,7 +35,7 @@ LOG_MODULE_REGISTER(eeprom, CONFIG_EEPROM_LOG_LEVEL);
 
 int eeprom_read_byte(uint16_t offset, uint8_t *data)
 {
-	uint8_t ret;
+	int ret;
 	uint8_t buf = OFS_MSB(offset);
 
 	ret = i2c_hub_write_read(I2C_0,
@@ -52,7 +52,7 @@ int eeprom_read_byte(uint16_t offset, uint8_t *data)
 
 int eeprom_write_byte(uint16_t offset, uint8_t data)
 {
-	uint8_t ret;
+	int ret;
 	uint8_t buf[] = { OFS_LSB(offset), data };
 
 	ret = i2c_hub_write(I2C_0, buf, sizeof(buf),
@@ -69,7 +69,7 @@ int eeprom_write_byte(uint16_t offset, uint8_t data)
 
 int eeprom_read_word(uint16_t offset, uint16_t *data)
 {
-	uint8_t ret;
+	int ret;
 	uint8_t buf = { OFS_LSB(offset) };
 	uint8_t rbuf[] = {EEPROM_DEFAULT_DATA, EEPROM_DEFAULT_DATA};
 
@@ -90,7 +90,7 @@ int eeprom_read_word(uint16_t offset, uint16_t *data)
 
 int eeprom_write_word(uint16_t offset, uint16_t data)
 {
-	uint16_t ret;
+	int ret;
 	uint8_t buf[] = { OFS_LSB(offset),
 		       OFS_MSB(data), OFS_LSB(data) };
 
@@ -109,7 +109,7 @@ int eeprom_write_word(uint16_t offset, uint16_t data)
 
 int eeprom_read_block(uint16_t offset, uint8_t len, uint8_t *data)
 {
-	uint16_t ret;
+	int ret;
 	uint8_t buf = { OFS_LSB(offset) };
 
 	if (len > DATA_MAX_LEN) {

--- a/drivers/eeprom.c
+++ b/drivers/eeprom.c
@@ -53,10 +53,10 @@ int eeprom_read_byte(uint16_t offset, uint8_t *data)
 int eeprom_write_byte(uint16_t offset, uint8_t data)
 {
 	int ret;
-	uint8_t buf[] = { OFS_LSB(offset), data };
+	uint8_t buf[] = { (uint8_t)OFS_LSB(offset), data };
 
 	ret = i2c_hub_write(I2C_0, buf, sizeof(buf),
-			EEPROM_DRIVER_I2C_ADDR | OFS_MSB(offset));
+			EEPROM_DRIVER_I2C_ADDR | (uint8_t)OFS_MSB(offset));
 	if (ret) {
 		LOG_ERR("Fail to write: %d", ret);
 		return ret;
@@ -91,11 +91,11 @@ int eeprom_read_word(uint16_t offset, uint16_t *data)
 int eeprom_write_word(uint16_t offset, uint16_t data)
 {
 	int ret;
-	uint8_t buf[] = { OFS_LSB(offset),
-		       OFS_MSB(data), OFS_LSB(data) };
+	uint8_t buf[] = { (uint8_t)OFS_LSB(offset),
+		       (uint8_t)OFS_MSB(data), (uint8_t)OFS_LSB(data) };
 
 	ret = i2c_hub_write(I2C_0, buf, sizeof(buf),
-			EEPROM_DRIVER_I2C_ADDR | OFS_MSB(offset));
+			EEPROM_DRIVER_I2C_ADDR | (uint8_t)OFS_MSB(offset));
 	if (ret) {
 		LOG_ERR("Fail to write: %d", ret);
 		return ret;


### PR DESCRIPTION
Initialize local variables before use in driver paths to avoid uninitialized-read warnings reported by Coverity.
Add explicit (uint8_t) casts to OFS_MSB() and OFS_LSB()