### PR TITLE
app: kbchost: Ensure ACK goes to host when PS2 keyboard is enabled

### DIFF
--- a/app/kbchost/kbchost.c
+++ b/app/kbchost/kbchost.c
@@ -390,7 +390,7 @@ static int process_keyboard_data(uint8_t data, uint8_t *output)
 #if defined(CONFIG_PS2_KEYBOARD)
 			ps2_keyboard_write(data);
 #endif
-			output[out_len] = KBC_8042_ACK;
+			output[out_len++] = KBC_8042_ACK;
 			break;
 		case KBC_8042_DEFAULT_DIS:
 			/* Set default and disable */


### PR DESCRIPTION
Ensure ACK goes to host when PS2 keyboard is enabled explicitly via KBC_8042_ENA_KB command as opposed to WRITE_CMD_BYTE with keyboard
 enable flag