### PR TITLE
drivers: espi_hub: Miscellaneous fixes

### DIFF
--- a/app/smchost/smchost.c
+++ b/app/smchost/smchost.c
@@ -316,7 +316,7 @@ static inline int smchost_task_init(void)
 				smchost_slatemode_handler);
 #endif
 	espihub_add_acpi_handler(ESPIHUB_ACPI_PUBLIC, smchost_acpi_handler);
-	espihub_add_warn_handler(ESPIHUB_RESET_WARNING,
+	espihub_add_warn_handler(ESPIHUB_HOST_RESET_WARNING,
 				 smchost_host_rst_warn_handler);
 	espihub_add_warn_handler(ESPIHUB_PLATFORM_RESET,
 				 smchost_pltrst_handler);

--- a/drivers/espi_hub.c
+++ b/drivers/espi_hub.c
@@ -15,7 +15,7 @@
 
 LOG_MODULE_REGISTER(espihub, CONFIG_ESPIHUB_LOG_LEVEL);
 
-#ifdef ENABLE_ESPI_LTR
+#ifdef CONFIG_ENABLE_ESPI_LTR
 /* LTR requirement enable */
 #define ESPI_LTR_REQ_ENABLE		1U
 /* LTR latency value in unit of scale */
@@ -267,21 +267,21 @@ static void espi_reset_handler(const struct device *dev,
 static void espi_ch_handler(const struct device *dev, struct espi_callback *cb,
 			    struct espi_event event)
 {
-#ifdef ENABLE_ESPI_LTR
-	int ltr_status;
-#endif
-
 	LOG_DBG("%d", event.evt_type);
 	if (event.evt_type == ESPI_BUS_EVENT_CHANNEL_READY) {
 		if (event.evt_details == ESPI_CHANNEL_VWIRE) {
-			LOG_INF("VW channel ready: %d", event.evt_data);
+			LOG_DBG("VW channel ready: %d", event.evt_data);
 			hub.host_vw_ready = event.evt_data;
-		}
-
-#ifdef ENABLE_ESPI_LTR
-		if (event.evt_details == ESPI_CHANNEL_PERIPHERAL) {
-			LOG_INF("PH channel is ready");
+		} else if (event.evt_details == ESPI_CHANNEL_OOB) {
+			LOG_DBG("OOB channel ready: %d", event.evt_data);
+		} else if (event.evt_details == ESPI_CHANNEL_FLASH) {
+			LOG_DBG("Flash channel ready: %d", event.evt_data);
+		} else if (event.evt_details == ESPI_CHANNEL_PERIPHERAL) {
+			LOG_DBG("PERIPH channel is ready");
+#ifdef CONFIG_ENABLE_ESPI_LTR
 			if (event.evt_data == ESPI_PC_EVT_BUS_MASTER_ENABLE) {
+				int ltr_status;
+
 				LOG_DBG("Sending ltr.... ");
 				ltr_status = espihub_send_ltr();
 				if (!ltr_status) {
@@ -291,8 +291,8 @@ static void espi_ch_handler(const struct device *dev, struct espi_callback *cb,
 						ltr_status);
 				}
 			}
-		}
 #endif
+		}
 	}
 }
 
@@ -656,7 +656,7 @@ int espihub_kbc_read(enum lpc_peripheral_opcode cmd, uint32_t *data)
 	return espi_read_lpc_request(espi_dev, cmd, data);
 }
 
-#ifdef ENABLE_ESPI_LTR
+#ifdef CONFIG_ENABLE_ESPI_LTR
 int espihub_send_ltr(void)
 {
 	struct ltr_cfg_pkt req;

--- a/drivers/espi_hub.c
+++ b/drivers/espi_hub.c
@@ -24,11 +24,19 @@ LOG_MODULE_REGISTER(espihub, CONFIG_ESPIHUB_LOG_LEVEL);
 
 static const struct device *espi_dev;
 static struct espihub_context hub;
-static espi_warn_handler_t warn_handlers[ESPIHUB_MAX_HANDLER_INDEX];
 static espi_state_handler_t state_handler;
 static espi_acpi_handler_t acpi_handlers[MAX_ACPI_HANDLERS];
 static espi_kbc_handler_t kbc_handler;
 static espi_postcode_handler_t postcode_handler;
+
+static espi_warn_handler_t host_rst_warn_handlers[MAX_HOST_RST_WARN_HANDLERS];
+static espi_warn_handler_t pltrst_warn_handlers[MAX_PLTRST_WARN_HANDLERS];
+static espi_warn_handler_t suspend_warn_handler;
+static espi_warn_handler_t dnx_warn_handler;
+static espi_warn_handler_t espi_bus_rst_warn_handler;
+
+static uint8_t pltrst_hndler_idx;
+static uint8_t host_rst_warn_hndler_idx;
 
 /* Registration from other modules */
 int espihub_add_state_handler(espi_state_handler_t handler)
@@ -47,12 +55,56 @@ int espihub_add_warn_handler(enum espihub_handler type,
 			      espi_warn_handler_t handler)
 {
 	__ASSERT(handler, "Handler shouldn't be NULL");
-	if (warn_handlers[type]) {
-		LOG_ERR("Only warn %d handler supported", type);
-		return -EINVAL;
+	int ret = 0;
+
+	switch (type) {
+	case ESPIHUB_HOST_RESET_WARNING:
+		if (host_rst_warn_hndler_idx < MAX_HOST_RST_WARN_HANDLERS) {
+			host_rst_warn_handlers[host_rst_warn_hndler_idx] = handler;
+			host_rst_warn_hndler_idx++;
+		} else {
+			ret = -EINVAL;
+		}
+		break;
+
+	case ESPIHUB_PLATFORM_RESET:
+		if (pltrst_hndler_idx < MAX_PLTRST_WARN_HANDLERS) {
+			pltrst_warn_handlers[pltrst_hndler_idx] = handler;
+			pltrst_hndler_idx++;
+		} else {
+			ret = -EINVAL;
+		}
+		break;
+
+	case ESPIHUB_SUSPEND_WARNING:
+		if (suspend_warn_handler) {
+			ret = -EINVAL;
+		} else {
+			suspend_warn_handler = handler;
+		}
+		break;
+
+	case ESPIHUB_DNX_WARNING:
+		if (dnx_warn_handler) {
+			ret = -EINVAL;
+		} else {
+			dnx_warn_handler = handler;
+		}
+	case ESPIHUB_BUS_RESET:
+		if (espi_bus_rst_warn_handler) {
+			ret = -EINVAL;
+		} else {
+			espi_bus_rst_warn_handler = handler;
+		}
+	default:
+		break;
 	}
 
-	warn_handlers[type] = handler;
+	if (ret) {
+		LOG_ERR("Warn handler %d registered already", type);
+		return ret;
+	}
+
 	return 0;
 }
 
@@ -127,17 +179,17 @@ static void host_warn_handler(uint32_t signal, uint32_t status)
 	switch (signal) {
 	case ESPI_VWIRE_SIGNAL_PLTRST:
 		LOG_INF("PLT_RST changed %d", status);
-		if (warn_handlers[ESPIHUB_PLATFORM_RESET]) {
-			warn_handlers[ESPIHUB_PLATFORM_RESET](status);
-		} else {
-			LOG_WRN("No PLT_RST handler registered");
+		for (int idx = 0; idx < pltrst_hndler_idx; idx++) {
+			if (pltrst_warn_handlers[idx]) {
+				pltrst_warn_handlers[idx](status);
+			}
 		}
 		break;
 	case ESPI_VWIRE_SIGNAL_HOST_RST_WARN:
-		if (warn_handlers[ESPIHUB_RESET_WARNING]) {
-			warn_handlers[ESPIHUB_RESET_WARNING](status);
-		} else {
-			LOG_WRN("No Host rst handler registered");
+		for (int idx = 0; idx < host_rst_warn_hndler_idx; idx++) {
+			if (host_rst_warn_handlers[idx]) {
+				host_rst_warn_handlers[idx](status);
+			}
 		}
 		LOG_INF("Send ACK HOST RST %d", status);
 		espi_send_vwire(espi_dev, ESPI_VWIRE_SIGNAL_HOST_RST_ACK,
@@ -149,8 +201,8 @@ static void host_warn_handler(uint32_t signal, uint32_t status)
 				status);
 		break;
 	case ESPI_VWIRE_SIGNAL_SUS_WARN:
-		if (warn_handlers[ESPIHUB_SUSPEND_WARNING]) {
-			warn_handlers[ESPIHUB_SUSPEND_WARNING](status);
+		if (suspend_warn_handler) {
+			suspend_warn_handler(status);
 		} else {
 			LOG_WRN("No suspend handler registered");
 		}
@@ -159,8 +211,8 @@ static void host_warn_handler(uint32_t signal, uint32_t status)
 		hub.dnx_mode = status;
 		LOG_INF("Send DnX WARN %d", status);
 		espi_send_vwire(espi_dev, ESPI_VWIRE_SIGNAL_DNX_ACK, status);
-		if (warn_handlers[ESPIHUB_DNX_WARNING]) {
-			warn_handlers[ESPIHUB_DNX_WARNING](status);
+		if (dnx_warn_handler) {
+			dnx_warn_handler(status);
 		} else {
 			LOG_WRN("No dnx handler registered");
 		}
@@ -188,9 +240,9 @@ static void espi_reset_handler(const struct device *dev,
 		}
 #endif
 
-		LOG_INF("eSPI BUS reset %d", event.evt_data);
-		if (warn_handlers[ESPIHUB_BUS_RESET]) {
-			warn_handlers[ESPIHUB_BUS_RESET](event.evt_data);
+		LOG_INF("eSPI BUS reset %d", hub.espi_rst_sts);
+		if (espi_bus_rst_warn_handler) {
+			espi_bus_rst_warn_handler(hub.espi_rst_sts);
 		} else {
 			LOG_WRN("No bus reset handler registered");
 		}

--- a/drivers/espi_hub.c
+++ b/drivers/espi_hub.c
@@ -33,8 +33,9 @@ static espi_warn_handler_t host_rst_warn_handlers[MAX_HOST_RST_WARN_HANDLERS];
 static espi_warn_handler_t pltrst_warn_handlers[MAX_PLTRST_WARN_HANDLERS];
 static espi_warn_handler_t suspend_warn_handler;
 static espi_warn_handler_t dnx_warn_handler;
-static espi_warn_handler_t espi_bus_rst_warn_handler;
+static espi_warn_handler_t espi_bus_rst_warn_handlers[MAX_ESPI_BUS_RST_HANDLERS];
 
+static uint8_t espi_bus_rst_hndler_idx;
 static uint8_t pltrst_hndler_idx;
 static uint8_t host_rst_warn_hndler_idx;
 
@@ -91,10 +92,11 @@ int espihub_add_warn_handler(enum espihub_handler type,
 			dnx_warn_handler = handler;
 		}
 	case ESPIHUB_BUS_RESET:
-		if (espi_bus_rst_warn_handler) {
-			ret = -EINVAL;
+		if (espi_bus_rst_hndler_idx < MAX_ESPI_BUS_RST_HANDLERS) {
+			espi_bus_rst_warn_handlers[espi_bus_rst_hndler_idx] = handler;
+			espi_bus_rst_hndler_idx++;
 		} else {
-			espi_bus_rst_warn_handler = handler;
+			ret = -EINVAL;
 		}
 	default:
 		break;
@@ -241,10 +243,13 @@ static void espi_reset_handler(const struct device *dev,
 #endif
 
 		LOG_INF("eSPI BUS reset %d", hub.espi_rst_sts);
-		if (espi_bus_rst_warn_handler) {
-			espi_bus_rst_warn_handler(hub.espi_rst_sts);
-		} else {
-			LOG_WRN("No bus reset handler registered");
+		for (int idx = 0; idx < espi_bus_rst_hndler_idx; idx++) {
+			if (espi_bus_rst_warn_handlers[idx]) {
+				espi_bus_rst_warn_handlers[idx](hub.espi_rst_sts);
+			}
+		}
+		if (!espi_bus_rst_hndler_idx) {
+			LOG_WRN("No eSPI bus reset handler registered");
 		}
 	}
 }

--- a/drivers/espi_hub.c
+++ b/drivers/espi_hub.c
@@ -237,6 +237,11 @@ static void espi_reset_handler(const struct device *dev,
 	LOG_WRN("%s", __func__);
 	if (event.evt_type == ESPI_BUS_RESET) {
 		hub.espi_rst_sts = event.evt_data;
+		/* this is required to catch the global reset*/
+		if (!hub.espi_rst_sts) {
+			LOG_ERR("ESPI reset status %d", hub.espi_rst_sts);
+			hub.espi_rst_transition_low = true;
+		}
 
 #if defined(CONFIG_SOC_SERIES_NPCX4)
 		if (hub.espi_rst_sts) {
@@ -516,6 +521,7 @@ int espihub_wait_for_vwire(enum espi_vwire_signal signal, uint16_t timeout,
 	uint8_t level;
 	int loop_cnt = timeout;
 
+	hub.espi_rst_transition_low = false;
 	do {
 		ret = espi_receive_vwire(espi_dev, signal, &level);
 		if (ret) {
@@ -528,6 +534,15 @@ int espihub_wait_for_vwire(enum espi_vwire_signal signal, uint16_t timeout,
 		}
 
 		k_usleep(100);
+		/* break the loop when global reset ocurred.
+		 * Introduced a new error code when the global reset ocurred
+		 * and the error code is 117.
+		 */
+		if (hub.espi_rst_transition_low == true) {
+			LOG_DBG("global reset ocurred while waiting for %d ", signal);
+			hub.espi_rst_transition_low = false;
+			return -EHOSTDOWN;
+		}
 		loop_cnt--;
 	} while (loop_cnt > 0 || (timeout == WAIT_TIMEOUT_FOREVER) ||
 		 ec_timeout_status());

--- a/drivers/espi_hub.c
+++ b/drivers/espi_hub.c
@@ -390,6 +390,25 @@ static void espi_oob_rx_handler(const struct device *dev,
 }
 #endif
 
+#ifndef CONFIG_ESPI_AUTOMATIC_BOOT_DONE_ACKNOWLEDGE
+void espihub_send_target_bootdone(int error)
+{
+	int ret;
+	uint8_t boot_done;
+
+	ret = espi_receive_vwire(espi_dev, ESPI_VWIRE_SIGNAL_SLV_BOOT_DONE,
+				 &boot_done);
+	LOG_WRN("%s boot_done: %d", __func__, boot_done);
+	if (ret) {
+		LOG_WRN("Fail to retrieve slave boot done");
+	} else if (!boot_done) {
+		/* SLAVE_BOOT_DONE & SLAVE_LOAD_STS have to be sent together */
+		espi_send_vwire(espi_dev, ESPI_VWIRE_SIGNAL_SLV_BOOT_STS, error ? 0 : 1);
+		espi_send_vwire(espi_dev, ESPI_VWIRE_SIGNAL_SLV_BOOT_DONE, 1);
+	}
+}
+#endif
+
 void detect_boot_mode(void)
 {
 	bool flash_sts;
@@ -567,6 +586,27 @@ int espihub_wait_for_espi_reset(uint8_t exp_sts, uint32_t timeout)
 		if (exp_sts == hub.espi_rst_sts) {
 			break;
 		}
+		k_usleep(100);
+		loop_cnt--;
+	} while (loop_cnt > 0 || (timeout == WAIT_TIMEOUT_FOREVER) ||
+		 ec_timeout_status());
+
+	if (loop_cnt == 0) {
+		return -ETIMEDOUT;
+	}
+
+	return 0;
+}
+
+int espihub_wait_for_flash_channel(uint16_t timeout)
+{
+	int loop_cnt = timeout;
+
+	do {
+		if (espi_get_channel_status(espi_dev, ESPI_CHANNEL_FLASH)) {
+			break;
+		}
+
 		k_usleep(100);
 		loop_cnt--;
 	} while (loop_cnt > 0 || (timeout == WAIT_TIMEOUT_FOREVER) ||

--- a/drivers/espi_hub.c
+++ b/drivers/espi_hub.c
@@ -22,6 +22,9 @@ LOG_MODULE_REGISTER(espihub, CONFIG_ESPIHUB_LOG_LEVEL);
 #define ESPI_LTR_LATENCY		2U
 #endif
 
+/* VW enum S3 starts at 0 */
+#define SLP_SX_STATE(vw)	(vw + 3)
+
 static const struct device *espi_dev;
 static struct espihub_context hub;
 static espi_state_handler_t state_handler;
@@ -309,7 +312,7 @@ static void vwire_handler(const struct device *dev, struct espi_callback *cb,
 		case ESPI_VWIRE_SIGNAL_SLP_S3:
 		case ESPI_VWIRE_SIGNAL_SLP_S4:
 		case ESPI_VWIRE_SIGNAL_SLP_S5:
-			LOG_INF("SLP %d changed %d", event.evt_details,
+			LOG_INF("SLP %d changed to %d", SLP_SX_STATE(event.evt_details),
 				event.evt_data);
 			if (state_handler) {
 				state_handler(event.evt_details,

--- a/drivers/espi_hub.c
+++ b/drivers/espi_hub.c
@@ -559,7 +559,7 @@ int espihub_wait_for_vwire(enum espi_vwire_signal signal, uint16_t timeout,
 	return 0;
 }
 
-int espihub_wait_for_espi_reset(uint8_t exp_sts, uint16_t timeout)
+int espihub_wait_for_espi_reset(uint8_t exp_sts, uint32_t timeout)
 {
 	int loop_cnt = timeout;
 

--- a/drivers/espi_hub.c
+++ b/drivers/espi_hub.c
@@ -181,7 +181,7 @@ bool espihub_dnx_status(void)
 
 static void host_warn_handler(uint32_t signal, uint32_t status)
 {
-	LOG_DBG("%s", __func__);
+	LOG_DBG("%d %d", signal, status);
 	switch (signal) {
 	case ESPI_VWIRE_SIGNAL_PLTRST:
 		LOG_INF("PLT_RST changed %d", status);
@@ -271,7 +271,7 @@ static void espi_ch_handler(const struct device *dev, struct espi_callback *cb,
 	int ltr_status;
 #endif
 
-	LOG_DBG("%s", __func__);
+	LOG_DBG("%d", event.evt_type);
 	if (event.evt_type == ESPI_BUS_EVENT_CHANNEL_READY) {
 		if (event.evt_details == ESPI_CHANNEL_VWIRE) {
 			LOG_INF("VW channel ready: %d", event.evt_data);
@@ -453,7 +453,7 @@ int espihub_init(void)
 		return -ENODEV;
 	}
 
-	LOG_DBG("About to configure eSPI device %s", __func__);
+	LOG_DBG("About to configure eSPI device");
 	ret = espi_config(espi_dev, &cfg);
 	if (ret) {
 		LOG_ERR("eSPI slave configured failed");
@@ -484,7 +484,7 @@ int espihub_init(void)
 						    ESPI_CHANNEL_VWIRE);
 	hub.espi_rst_sts = gpio_read_pin(ESPI_RESET_MAF);
 
-	LOG_DBG("%s hub.host_vw_ready: %d", __func__, hub.host_vw_ready);
+	LOG_DBG("hub.host_vw_ready: %d", hub.host_vw_ready);
 
 #if defined(CONFIG_SOC_SERIES_NPCX4)
 	uint32_t enable = 1;
@@ -499,7 +499,7 @@ static int handle_vw_ack(enum espi_vwire_signal signal, uint8_t value)
 {
 	int ret;
 
-	LOG_DBG("%s", __func__);
+	LOG_DBG("%d", value);
 	switch (signal) {
 	case ESPI_VWIRE_SIGNAL_SUS_WARN:
 		ret = espi_send_vwire(espi_dev, ESPI_VWIRE_SIGNAL_SUS_ACK,

--- a/drivers/espi_hub.c
+++ b/drivers/espi_hub.c
@@ -91,6 +91,8 @@ int espihub_add_warn_handler(enum espihub_handler type,
 		} else {
 			dnx_warn_handler = handler;
 		}
+		break;
+
 	case ESPIHUB_BUS_RESET:
 		if (espi_bus_rst_hndler_idx < MAX_ESPI_BUS_RST_HANDLERS) {
 			espi_bus_rst_warn_handlers[espi_bus_rst_hndler_idx] = handler;
@@ -98,6 +100,8 @@ int espihub_add_warn_handler(enum espihub_handler type,
 		} else {
 			ret = -EINVAL;
 		}
+		break;
+
 	default:
 		break;
 	}

--- a/drivers/espi_hub.h
+++ b/drivers/espi_hub.h
@@ -23,6 +23,8 @@
 #define MIN_ESPI_FREQ             20u
 #define MAX_ESPI_FREQ             66u
 
+#define MAX_PLTRST_WARN_HANDLERS  2u
+#define MAX_HOST_RST_WARN_HANDLERS 2u
 #define MAX_ACPI_HANDLERS         2u
 #define MAX_PERIPH_HANDLERS       2u
 
@@ -43,7 +45,7 @@ typedef void (*espi_postcode_handler_t)(uint8_t port_index, uint32_t code);
 #define	ESPIHUB_VW_HIGH	1
 
 enum espihub_handler {
-	ESPIHUB_RESET_WARNING,
+	ESPIHUB_HOST_RESET_WARNING,
 	ESPIHUB_PLATFORM_RESET,
 	ESPIHUB_SUSPEND_WARNING,
 	ESPIHUB_DNX_WARNING,

--- a/drivers/espi_hub.h
+++ b/drivers/espi_hub.h
@@ -23,6 +23,7 @@
 #define MIN_ESPI_FREQ             20u
 #define MAX_ESPI_FREQ             66u
 
+#define MAX_ESPI_BUS_RST_HANDLERS 2u
 #define MAX_PLTRST_WARN_HANDLERS  2u
 #define MAX_HOST_RST_WARN_HANDLERS 2u
 #define MAX_ACPI_HANDLERS         2u

--- a/drivers/espi_hub.h
+++ b/drivers/espi_hub.h
@@ -80,6 +80,7 @@ struct espihub_context {
 	/* SPI flash sharing config detection */
 	enum boot_config_mode spi_boot_mode;
 	bool boot_config_detected;
+	bool espi_rst_transition_low;
 };
 
 /**

--- a/drivers/espi_hub.h
+++ b/drivers/espi_hub.h
@@ -123,7 +123,7 @@ bool espihub_dnx_status(void);
  *
  * @retval -ETIMEDOUT or 0 if success.
  */
-int espihub_wait_for_espi_reset(uint8_t exp_sts, uint16_t timeout);
+int espihub_wait_for_espi_reset(uint8_t exp_sts, uint32_t timeout);
 
 /**
  * @brief Poll eSPI virtual wire until asserted/de-asserted.

--- a/drivers/espi_hub.h
+++ b/drivers/espi_hub.h
@@ -138,6 +138,16 @@ int espihub_wait_for_espi_reset(uint8_t exp_sts, uint32_t timeout);
 int espihub_wait_for_vwire(enum espi_vwire_signal signal, uint16_t timeout,
 		   uint8_t exp_level, bool ack_required);
 
+
+/**
+ * @brief Poll for eSPI flash channel negotiation to be complete.
+ *
+ * @param timeout value expressed in multiple of 100us.
+ *
+ * @retval -ETIMEDOUT or success.
+ */
+int espihub_wait_for_flash_channel(uint16_t timeout);
+
 /**
  * @brief Poll signal while monitoring eSPI virtual wire.
  *
@@ -336,4 +346,16 @@ int espihub_read_flash(struct espi_flash_packet *pckt);
  * @retval -EIO General input / output error, failed request to master.
  */
 int espihub_erase_flash(struct espi_flash_packet *pckt);
+
+/**
+ * @brief Signal EC FW fetching complete is complete by sending eSPI virtual wires
+ *
+ * This routine sends TARGET_BOOT_DONE and TARGET_BOOT_STATUS virtual wires
+ *
+ * @param error Indicates if EC FW fetching procedure completed successfully.
+ *
+ * @retval -EIO General input / output error.
+ */
+void espihub_send_target_bootdone(int error);
+
 #endif /* __ESPI_HUB_H__ */

--- a/drivers/peci_hub.c
+++ b/drivers/peci_hub.c
@@ -265,7 +265,7 @@ static int espioob_peci_transfer(struct peci_msg *msg)
 	uint8_t oob_byte_cnt =  OOB_PECI_REQ_HDR_SIZE + msg->tx_buffer.len;
 	int ret;
 
-	LOG_DBG("%s:Msg TxLen-%d, RxLen-%d", __func__,
+	LOG_DBG("Msg TxLen-%d, RxLen-%d",
 			msg->tx_buffer.len, msg->rx_buffer.len);
 	oob_req.oob_dest_addr = PCH_OOB_PECI_SLV_ADDR;
 	oob_req.oob_cmd_code = PECI_OOB_CMD_CODE;
@@ -339,7 +339,7 @@ static int peci_exec_transfer(struct peci_msg *msg)
 	}
 
 	for (int i = 0; i < rd_len; i++) {
-		LOG_DBG("%s:Rx[%d]-%02x", __func__, i,
+		LOG_DBG("Rx[%d]-%02x", i,
 				msg->rx_buffer.buf[i]);
 	}
 


### PR DESCRIPTION
- Allow multiple warn handlers for specific type.
- Handle global reset issue when DAM(delayaed authentication method) 
- Remove redundant log parameter
- Allow larger eSPI power sequencing timeouts.
- Add support to signal EC FW fetching complete explicitly