### PR TITLE
app: pwrseq: Miscellaneous fixes

### DIFF
--- a/app/app.c
+++ b/app/app.c
@@ -23,13 +23,7 @@ int main(void)
 	int ret;
 
 	/* Delayed start for debug */
-	k_sleep(K_SECONDS(CONFIG_EC_DELAYED_BOOT));
-
-	/* In platform N-1 rework doesn't route SMC_RST to MECC card, causing
-	 * I2C glitches among other issues, add a delay to get postcodes
-	 * until HW WA is possible.
-	 */
-	k_msleep(100);
+	k_msleep(CONFIG_EC_DELAYED_BOOT);
 
 	LOG_INF("EC FW Zephyr %p %s", k_current_get(), CONFIG_BOARD);
 

--- a/app/power_sequencing/Kconfig
+++ b/app/power_sequencing/Kconfig
@@ -39,6 +39,15 @@ config EC_DELAYED_BOOT
 	  Indicate if EC FW boot is delayed for N miliseconds. This is useful to
 	  debug early app initialization via serial logs or JTAG.
 
+config DEPRECATED_DPWROK_HANDLING
+	bool "Drive dpwrok to low in DeepSx enabled systems"
+	help
+	  EC FW need to drive DPWR_OK to low(recovery indicator is used
+	  to drive dpwr_ok) along with RSMRST_N low to meet the power
+	  sequence's requirement in Deepsx supported systems as per the
+	  PDG when performing EC reset
+
+
 config PWRMGT_LOG_LEVEL
 	int "Power management log level"
 	depends on PWRMGMT

--- a/app/power_sequencing/Kconfig
+++ b/app/power_sequencing/Kconfig
@@ -36,7 +36,7 @@ config EC_DELAYED_BOOT
 	int "Enable EC FW delayed boot"
 	default 0
 	help
-	  Indicate if EC FW boot is delayed for N seconds. This is useful to
+	  Indicate if EC FW boot is delayed for N miliseconds. This is useful to
 	  debug early app initialization via serial logs or JTAG.
 
 config PWRMGT_LOG_LEVEL

--- a/app/power_sequencing/dswmode.c
+++ b/app/power_sequencing/dswmode.c
@@ -25,20 +25,21 @@ static bool dsw_mode_update;
 
 bool dsw_enabled(void)
 {
-#ifndef CONFIG_PWRMGMT_DEEPSX
+#ifdef CONFIG_PWRMGMT_DEEPSX
+	return dsw_valid_config != 0;
+#else
 	return false;
 #endif
-	return dsw_valid_config != 0;
 }
 
 uint8_t dsw_mode(void)
 {
-#ifndef CONFIG_PWRMGMT_DEEPSX
+#ifdef CONFIG_PWRMGMT_DEEPSX
+	LOG_DBG("Current Dsx mode %x", dsw_valid_config);
+	return dsw_valid_config;
+#else
 	return DSW_DISABLED;
 #endif
-	LOG_DBG("Current Dsx mode %x", dsw_valid_config);
-
-	return dsw_valid_config;
 }
 
 void dsw_update_mode(uint8_t mode)

--- a/app/power_sequencing/pmc.c
+++ b/app/power_sequencing/pmc.c
@@ -15,11 +15,12 @@ LOG_MODULE_DECLARE(pwrmgmt, CONFIG_PWRMGT_LOG_LEVEL);
 
 #define PMC_RESET_PAYLOAD_SIZE 1U
 
-int pmc_reset_soc(enum pmc_request req_type)
+int pmc_reset_soc(enum pmc_request req_type, bool sync)
 {
 	uint8_t buf[sizeof(struct oob_msg_str) + PMC_RESET_PAYLOAD_SIZE];
 	struct espi_oob_packet req_pckt;
 	struct oob_msg_str oob_msg;
+	int ret = 0;
 
 	LOG_DBG("%s", __func__);
 
@@ -34,8 +35,16 @@ int pmc_reset_soc(enum pmc_request req_type)
 	req_pckt.buf = buf;
 	req_pckt.len = sizeof(buf);
 
-	if (oob_send_async(&req_pckt, NULL, OOB_TX_HAS_RX)) {
-		LOG_ERR("PMC request failed");
+	if (sync) {
+		/* Do send the OOB PMC request immediately */
+		ret = oob_send_sync(&req_pckt, NULL, OOB_TX_HAS_RX, MIN_WAIT_TIME_FOR_OOB_IN_MS);
+	} else {
+		/* Queue request */
+		ret = oob_send_async(&req_pckt, NULL, OOB_TX_HAS_RX);
+	}
+
+	if (ret) {
+		LOG_ERR("PMC request failed %d\n", ret);
 		return -EIO;
 	}
 

--- a/app/power_sequencing/pmc.c
+++ b/app/power_sequencing/pmc.c
@@ -18,8 +18,8 @@ LOG_MODULE_DECLARE(pwrmgmt, CONFIG_PWRMGT_LOG_LEVEL);
 int pmc_reset_soc(enum pmc_request req_type, bool sync)
 {
 	uint8_t buf[sizeof(struct oob_msg_str) + PMC_RESET_PAYLOAD_SIZE];
-	struct espi_oob_packet req_pckt;
-	struct oob_msg_str oob_msg;
+	struct espi_oob_packet req_pckt = {0};
+	struct oob_msg_str oob_msg = {0};
 	int ret = 0;
 
 	LOG_DBG("%s", __func__);

--- a/app/power_sequencing/pmc.h
+++ b/app/power_sequencing/pmc.h
@@ -24,6 +24,7 @@ enum pmc_request {
  * @brief Resets the SoC (host) making use of eSPI OOB
  *
  * @param reset_type system reset requested. See enum pmc_request.
+ * @param sync operation won't be queued but carried away synchronously.
  *
  * @retval -EIO General input / output error, failed to configure device.
  * @retval -ENOTSUP capability not supported.
@@ -31,6 +32,6 @@ enum pmc_request {
  *
  */
 
-int pmc_reset_soc(enum pmc_request reset_type);
+int pmc_reset_soc(enum pmc_request req_type, bool sync);
 
 #endif /* __PMC_H__ */

--- a/app/power_sequencing/pseudog3.c
+++ b/app/power_sequencing/pseudog3.c
@@ -66,12 +66,15 @@ static bool is_pseudo_g3_condition(void)
 		return false;
 	}
 
-	if (gpio_read_pin(ESPI_RESET_MAF) > 0) {
-		espihub_retrieve_vw(ESPI_VWIRE_SIGNAL_SUS_PWRDN_ACK, &sus_pwrdn_ack);
-		if (!sus_pwrdn_ack) {
-			LOG_DBG("No Pseudo G3 with sus_pwrdn_ack:0");
-			return false;
-		}
+	if (gpio_read_pin(ESPI_RESET_MAF) <= 0) {
+		LOG_WRN("No Pseudo G3 when eSPI reset is low");
+		return false;
+	}
+
+	espihub_retrieve_vw(ESPI_VWIRE_SIGNAL_SUS_PWRDN_ACK, &sus_pwrdn_ack);
+	if (!sus_pwrdn_ack) {
+		LOG_WRN("No Pseudo G3 with sus_pwrdn_ack:0");
+		return false;
 	}
 	return true;
 }

--- a/app/power_sequencing/pseudog3.c
+++ b/app/power_sequencing/pseudog3.c
@@ -85,6 +85,12 @@ static void pseudo_g3_trigger_exit(void)
 	k_msleep(10);
 	gpio_write_pin(EC_PG3_EXIT, 0);
 
+	/* Re-enable generic HID wake sources */
+	gpio_interrupt_configure_pin(SMC_LID, GPIO_INT_EDGE_BOTH);
+	gpio_interrupt_configure_pin(VOL_UP, GPIO_INT_EDGE_BOTH);
+	gpio_interrupt_configure_pin(VOL_DOWN, GPIO_INT_EDGE_BOTH);
+	gpio_interrupt_configure_pin(HOME_BUTTON, GPIO_INT_EDGE_BOTH);
+
 #ifdef CONFIG_PWRMGMT_PG3_EXIT_WAKE_FROM_SX
 	/* If needed to wake system from Sx after PG3 exit, send the wake. */
 	pwrbtn_trigger_wake();
@@ -199,6 +205,16 @@ static void pg3_handle_state_waiting_entry(void)
 			gpio_write_pin(PM_DS3, 0);
 
 			pseudo_g3_set_state(PG3_STATE_ENTERED);
+
+			/* Disable generic EC HID wake sources.
+			 * During PG3 entry the pull-ups for these signals lose power, which leads
+			 * to polling, so this prevents polling (and I2C when using IO expander)
+			 * And also, if EC LPM is entered prevents an immediate EC LPM wake.
+			 */
+			gpio_interrupt_configure_pin(SMC_LID, GPIO_INT_DISABLE);
+			gpio_interrupt_configure_pin(VOL_UP, GPIO_INT_DISABLE);
+			gpio_interrupt_configure_pin(VOL_DOWN, GPIO_INT_DISABLE);
+			gpio_interrupt_configure_pin(HOME_BUTTON, GPIO_INT_DISABLE);
 			return;
 		}
 	default:
@@ -236,7 +252,7 @@ static void pg3_handle_state_entered(void)
 			return;
 		}
 
-		if (gpio_read_pin(PM_RSMRST) > 0) {
+		if (gpio_read_pin(RSMRST_PWRGD) > 0) {
 			LOG_DBG("PG3 Wake triggered");
 			pseudo_g3_set_state(PG3_STATE_WAKE_WAIT);
 			return;
@@ -299,14 +315,19 @@ void pseudo_g3_enable(bool status)
 	LOG_DBG("pg3_enable_status:%d", status);
 }
 
-bool pseudo_g3_get_state(void)
+inline bool pseudo_g3_get_state(void)
 {
 	return (pg3_state == PG3_STATE_ENTERED);
 }
 
-bool pseudo_g3_get_prev_state(void)
+inline bool pseudo_g3_get_prev_state(void)
 {
 	return (pg3_prev_state == PG3_STATE_ENTERED);
+}
+
+inline bool is_pseudo_g3_enabled(void)
+{
+	return pg3_enable_status;
 }
 
 void manage_pseudog3(void)

--- a/app/power_sequencing/pseudog3.h
+++ b/app/power_sequencing/pseudog3.h
@@ -24,6 +24,13 @@ enum pg3_counter {
 void pseudo_g3_enable(bool state);
 
 /**
+ * @brief Get the if Pseudo G3 is enabled in the system.
+ *
+ * @return true if system has pseudo g3 enabled otherwise false.
+ */
+bool is_pseudo_g3_enabled(void);
+
+/**
  * @brief Get the current state of Pseudo G3.
  *
  * @return true if system is in pseudo g3 otherwise false.

--- a/app/power_sequencing/pwrplane.c
+++ b/app/power_sequencing/pwrplane.c
@@ -118,6 +118,13 @@ void disable_ec_timeout(void)
 	}
 }
 
+void enable_ec_timeout(void)
+{
+	if (pwrseq_timeout_disabled) {
+		pwrseq_timeout_disabled = false;
+	}
+}
+
 bool ec_timeout_status(void)
 {
 	return pwrseq_timeout_disabled;

--- a/app/power_sequencing/pwrplane.c
+++ b/app/power_sequencing/pwrplane.c
@@ -501,6 +501,7 @@ static bool pwrseq_handle_transition_to_s3(void)
 	case SYSTEM_S0_STATE: /* S0 -> S3 */
 		suspend();
 		valid_transition = true;
+		break;
 	case SYSTEM_G3_STATE: /* G3 -> S3 */
 	case SYSTEM_S5_STATE: /* S5 -> S3 */
 	case SYSTEM_S4_STATE: /* S4 -> S3 */

--- a/app/power_sequencing/pwrseq_timeouts.h
+++ b/app/power_sequencing/pwrseq_timeouts.h
@@ -24,6 +24,7 @@
 #define ALL_SYS_PWRGD_TIMEOUT       10000
 /* 500 ms */
 #define RSMRST_PWRDG_TIMEOUT        5000
+#define FLASH_CHANNEL_READY_TIMEOUT 5000
 /* 500 ms */
 #define ESPI_RST_TIMEOUT            5000
 /* 6s */

--- a/app/power_sequencing/pwrseq_utils.c
+++ b/app/power_sequencing/pwrseq_utils.c
@@ -75,6 +75,14 @@ void ec_reset(void)
 	gpio_write_pin(PM_RSMRST, 0);
 	LOG_DBG("%s: Before calling the reset_ec_chip", __func__);
 
+#ifdef CONFIG_DEPRECATED_DPWROK_HANDLING
+	/* EC FW need to drive DPWR_OK to low(recovery indicator is used
+	 * to drive dpwr_ok) along with RSMRST_N low to meet the power
+	 * sequence's requirement in Deepsx supported systems as per the
+	 * PDG when performing EC reset
+	 */
+	gpio_write_pin(RECOVERY_INDICATOR_N, 0);
+#endif
 	ec_arm_reset();
 
 	/* Flush logging subsystem buffer prior to reset */

--- a/app/power_sequencing/pwrseq_utils.h
+++ b/app/power_sequencing/pwrseq_utils.h
@@ -22,6 +22,13 @@ void ec_reset(void);
 void disable_ec_timeout(void);
 
 /**
+ * @brief Override EC timeout mechanism.
+ *
+ */
+void enable_ec_timeout(void);
+
+
+/**
  * @brief Perform evaluation of EC timeout HW strap.
  *
  */


### PR DESCRIPTION
- Remove unnecessary delay that affects SUS_ACK on G3 for all boards.
- Drive recovery indicator along with rsmrst during ec reset in deepsx enabled systems
- Add eSPI flash channel ready timeout value
- Check the eSPI status before PG3 entry
- Handle HID wake sources during PG3 entry/exit
- Add option to send PMC SoC request immediately instead of queueing the OOB reset request.
- Coverity issues
